### PR TITLE
Provide option for external identifiers

### DIFF
--- a/manipcassandra/manipulator.go
+++ b/manipcassandra/manipulator.go
@@ -134,7 +134,9 @@ func (c *cassandraManipulator) Create(context *manipulate.Context, objects ...ma
 	batch := c.batchForID(transactionID)
 
 	for _, object := range objects {
-		object.SetIdentifier(gocql.TimeUUID().String())
+		if object.Identifier() == "" {
+			object.SetIdentifier(gocql.TimeUUID().String())
+		}
 		list, values, err := cassandra.FieldsAndValues(object)
 
 		if err != nil {


### PR DESCRIPTION
In some instances we need to create the ID externally before the object
(Specific use case is creating a certificate with an ID before commit to the DB).