### PR TITLE
WIP Added new manipulator constructors

### DIFF
--- a/maniphttp/manipulator.go
+++ b/maniphttp/manipulator.go
@@ -36,18 +36,28 @@ type httpManipulator struct {
 }
 
 // NewHTTPManipulator returns a Manipulator backed by an ReST API.
-func NewHTTPManipulator(username, password, url, namespace string) manipulate.Manipulator {
+func NewHTTPManipulator(username, password, url string) manipulate.Manipulator {
+	return NewHTTPManipulatorWithNamespace(username, password, url, "")
+}
+
+// NewHTTPManipulatorWithNamespace returns a Manipulator backed by an ReST API.
+func NewHTTPManipulatorWithNamespace(username, password, url, namespace string) manipulate.Manipulator {
 
 	CAPool, err := x509.SystemCertPool()
 	if err != nil {
 		log.Error("Unable to load system root cert pool. tls fallback to unsecure.")
 	}
 
-	return NewHTTPManipulatorWithRootCA(username, password, url, namespace, CAPool, true)
+	return NewHTTPManipulatorWithRootCAAndNamespace(username, password, url, namespace, CAPool, true)
 }
 
 // NewHTTPManipulatorWithRootCA returns a Manipulator backed by an ReST API using the given CAPool as root CA.
-func NewHTTPManipulatorWithRootCA(username, password, url, namespace string, rootCAPool *x509.CertPool, skipTLSVerify bool) manipulate.Manipulator {
+func NewHTTPManipulatorWithRootCA(username, password, url string, rootCAPool *x509.CertPool, skipTLSVerify bool) manipulate.Manipulator {
+	return NewHTTPManipulatorWithRootCAAndNamespace(username, password, url, "", rootCAPool, skipTLSVerify)
+}
+
+// NewHTTPManipulatorWithRootCAAndNamespace returns a Manipulator backed by an ReST API using the given CAPool as root CA.
+func NewHTTPManipulatorWithRootCAAndNamespace(username, password, url, namespace string, rootCAPool *x509.CertPool, skipTLSVerify bool) manipulate.Manipulator {
 
 	tlsConfig := &tls.Config{
 		InsecureSkipVerify: skipTLSVerify,

--- a/maniphttp/manipulator_test.go
+++ b/maniphttp/manipulator_test.go
@@ -19,7 +19,7 @@ func TestHTTP_NewSHTTPStore(t *testing.T) {
 
 	Convey("When I create a new HTTPStore", t, func() {
 
-		store := NewHTTPManipulator("username", "password", "http://url.com", "myns").(*httpManipulator)
+		store := NewHTTPManipulatorWithNamespace("username", "password", "http://url.com", "myns").(*httpManipulator)
 
 		Convey("Then the property Username should be 'username'", func() {
 			So(store.username, ShouldEqual, "username")
@@ -56,7 +56,7 @@ func TestHTTP_makeAuthorizationHeaders(t *testing.T) {
 
 		Convey("When I prepare the Authorization", func() {
 
-			store := NewHTTPManipulator("username", "password", "http://url.com", "").(*httpManipulator)
+			store := NewHTTPManipulatorWithNamespace("username", "password", "http://url.com", "").(*httpManipulator)
 			h := store.makeAuthorizationHeaders()
 
 			Convey("Then the header should be correct", func() {
@@ -70,7 +70,7 @@ func TestHTTP_prepareHeaders(t *testing.T) {
 
 	Convey("Given I create an authenticated session", t, func() {
 
-		store := NewHTTPManipulator("username", "password", "http://fake.com", "myns").(*httpManipulator)
+		store := NewHTTPManipulatorWithNamespace("username", "password", "http://fake.com", "myns").(*httpManipulator)
 
 		Convey("Given I create a Request", func() {
 
@@ -96,7 +96,7 @@ func TestHTTP_readHeaders(t *testing.T) {
 
 	Convey("Given I create a new HTTPStore an a Context", t, func() {
 
-		store := NewHTTPManipulator("username", "password", "http://fake.com", "").(*httpManipulator)
+		store := NewHTTPManipulatorWithNamespace("username", "password", "http://fake.com", "").(*httpManipulator)
 		ctx := manipulate.NewContext()
 		req := &http.Response{Header: http.Header{}}
 
@@ -127,7 +127,7 @@ func TestHTTP_standardURI(t *testing.T) {
 
 		list := NewList()
 
-		store := NewHTTPManipulator("username", "password", "http://url.com", "").(*httpManipulator)
+		store := NewHTTPManipulatorWithNamespace("username", "password", "http://url.com", "").(*httpManipulator)
 
 		Convey("When I check personal URI of a standard object with an ID", func() {
 
@@ -219,7 +219,7 @@ func TestHTTP_Retrieve(t *testing.T) {
 		}))
 		defer ts.Close()
 
-		store := NewHTTPManipulator("username", "password", ts.URL, "")
+		store := NewHTTPManipulatorWithNamespace("username", "password", ts.URL, "")
 
 		Convey("When I fetch an entity", func() {
 
@@ -256,7 +256,7 @@ func TestHTTP_Retrieve(t *testing.T) {
 		}))
 		defer ts.Close()
 
-		store := NewHTTPManipulator("username", "password", ts.URL, "")
+		store := NewHTTPManipulatorWithNamespace("username", "password", ts.URL, "")
 
 		Convey("When I fetch an entity", func() {
 
@@ -280,7 +280,7 @@ func TestHTTP_Retrieve(t *testing.T) {
 		}))
 		defer ts.Close()
 
-		store := NewHTTPManipulator("username", "password", ts.URL, "")
+		store := NewHTTPManipulatorWithNamespace("username", "password", ts.URL, "")
 
 		Convey("When I fetch an entity", func() {
 
@@ -306,7 +306,7 @@ func TestHTTP_Update(t *testing.T) {
 		}))
 		defer ts.Close()
 
-		store := NewHTTPManipulator("username", "password", ts.URL, "")
+		store := NewHTTPManipulatorWithNamespace("username", "password", ts.URL, "")
 
 		Convey("When I save an entity", func() {
 
@@ -353,7 +353,7 @@ func TestHTTP_Update(t *testing.T) {
 		}))
 		defer ts.Close()
 
-		store := NewHTTPManipulator("username", "password", ts.URL, "")
+		store := NewHTTPManipulatorWithNamespace("username", "password", ts.URL, "")
 
 		Convey("When I save an entity", func() {
 
@@ -375,7 +375,7 @@ func TestHTTP_Update(t *testing.T) {
 		}))
 		defer ts.Close()
 
-		store := NewHTTPManipulator("username", "password", ts.URL, "")
+		store := NewHTTPManipulatorWithNamespace("username", "password", ts.URL, "")
 
 		Convey("When I save an entity", func() {
 
@@ -397,7 +397,7 @@ func TestHTTP_Update(t *testing.T) {
 		}))
 		defer ts.Close()
 
-		store := NewHTTPManipulator("username", "password", ts.URL, "")
+		store := NewHTTPManipulatorWithNamespace("username", "password", ts.URL, "")
 
 		Convey("When I save an entity", func() {
 
@@ -420,7 +420,7 @@ func TestHTTP_Delete(t *testing.T) {
 		}))
 		defer ts.Close()
 
-		store := NewHTTPManipulator("username", "password", ts.URL, "")
+		store := NewHTTPManipulatorWithNamespace("username", "password", ts.URL, "")
 
 		Convey("When I delete an entity", func() {
 
@@ -436,7 +436,7 @@ func TestHTTP_Delete(t *testing.T) {
 
 		Convey("When I delete an entity with no ID", func() {
 
-			store := NewHTTPManipulator("username", "password", "http://fake.com", "")
+			store := NewHTTPManipulatorWithNamespace("username", "password", "http://fake.com", "")
 
 			list := NewList()
 			err := store.Delete(nil, list)
@@ -455,7 +455,7 @@ func TestHTTP_Delete(t *testing.T) {
 		}))
 		defer ts.Close()
 
-		store := NewHTTPManipulator("username", "password", ts.URL, "")
+		store := NewHTTPManipulatorWithNamespace("username", "password", ts.URL, "")
 
 		Convey("When I delete an entity", func() {
 
@@ -486,7 +486,7 @@ func TestHTTP_RetrieveMany(t *testing.T) {
 			}))
 			defer ts.Close()
 
-			store := NewHTTPManipulator("username", "password", ts.URL, "")
+			store := NewHTTPManipulatorWithNamespace("username", "password", ts.URL, "")
 
 			var l TasksList
 			ctx := manipulate.NewContext()
@@ -519,7 +519,7 @@ func TestHTTP_RetrieveMany(t *testing.T) {
 
 		Convey("When I fetch its children but the parent has no ID", func() {
 
-			store := NewHTTPManipulator("username", "password", "http://fake.com", "")
+			store := NewHTTPManipulatorWithNamespace("username", "password", "http://fake.com", "")
 
 			list2 := NewList()
 			var l TasksList
@@ -541,7 +541,7 @@ func TestHTTP_RetrieveMany(t *testing.T) {
 			}))
 			defer ts.Close()
 
-			store := NewHTTPManipulator("username", "password", ts.URL, "")
+			store := NewHTTPManipulatorWithNamespace("username", "password", ts.URL, "")
 
 			e := NewTask()
 			var l TasksList
@@ -568,7 +568,7 @@ func TestHTTP_RetrieveMany(t *testing.T) {
 				fmt.Fprint(w, `[]`)
 			}))
 			defer ts.Close()
-			store := NewHTTPManipulator("username", "password", ts.URL, "")
+			store := NewHTTPManipulatorWithNamespace("username", "password", ts.URL, "")
 
 			var l TasksList
 
@@ -590,7 +590,7 @@ func TestHTTP_RetrieveMany(t *testing.T) {
 			}))
 			defer ts.Close()
 
-			store := NewHTTPManipulator("username", "password", ts.URL, "")
+			store := NewHTTPManipulatorWithNamespace("username", "password", ts.URL, "")
 
 			ctx := manipulate.NewContext()
 			ctx.Parent = list
@@ -611,7 +611,7 @@ func TestHTTP_RetrieveMany(t *testing.T) {
 			}))
 			defer ts.Close()
 
-			store := NewHTTPManipulator("username", "password", ts.URL, "")
+			store := NewHTTPManipulatorWithNamespace("username", "password", ts.URL, "")
 
 			ctx := manipulate.NewContext()
 			ctx.Parent = list
@@ -642,7 +642,7 @@ func TestHTTP_Create(t *testing.T) {
 			}))
 			defer ts.Close()
 
-			store := NewHTTPManipulator("username", "password", ts.URL, "")
+			store := NewHTTPManipulatorWithNamespace("username", "password", ts.URL, "")
 			task := NewTask()
 			errs := store.Create(nil, list, task)
 
@@ -657,7 +657,7 @@ func TestHTTP_Create(t *testing.T) {
 
 		Convey("When I create a child for a parent that has no ID", func() {
 
-			store := NewHTTPManipulator("username", "password", "url.com", "")
+			store := NewHTTPManipulatorWithNamespace("username", "password", "url.com", "")
 			list2 := NewList()
 			task := NewTask()
 			ctx := manipulate.NewContext()
@@ -672,7 +672,7 @@ func TestHTTP_Create(t *testing.T) {
 
 		Convey("When I create a child that is nil", func() {
 
-			store := NewHTTPManipulator("username", "password", "http://fake.com", "")
+			store := NewHTTPManipulatorWithNamespace("username", "password", "http://fake.com", "")
 			task := NewUnmarshalableList() // c'mon, that's fine..
 			errs := store.Create(nil, list, task)
 
@@ -688,7 +688,7 @@ func TestHTTP_Create(t *testing.T) {
 			}))
 			defer ts.Close()
 
-			store := NewHTTPManipulator("username", "password", ts.URL, "")
+			store := NewHTTPManipulatorWithNamespace("username", "password", ts.URL, "")
 			task := NewTask()
 			errs := store.Create(nil, list, task)
 
@@ -706,7 +706,7 @@ func TestHTTP_Create(t *testing.T) {
 			}))
 			defer ts.Close()
 
-			store := NewHTTPManipulator("username", "password", ts.URL, "")
+			store := NewHTTPManipulatorWithNamespace("username", "password", ts.URL, "")
 			task := NewTask()
 			errs := store.Create(nil, list, task)
 
@@ -717,7 +717,7 @@ func TestHTTP_Create(t *testing.T) {
 
 		Convey("When I create an unmarshalable entity", func() {
 
-			store := NewHTTPManipulator("username", "password", "", "")
+			store := NewHTTPManipulatorWithNamespace("username", "password", "", "")
 			list := NewUnmarshalableList()
 			list.ID = "yyy"
 			err := store.Create(nil, list)
@@ -744,7 +744,7 @@ func TestHTTP_Assign(t *testing.T) {
 			}))
 			defer ts.Close()
 
-			session := NewHTTPManipulator("username", "password", ts.URL, "s")
+			session := NewHTTPManipulatorWithNamespace("username", "password", ts.URL, "s")
 
 			t1 := NewTask()
 			t1.ID = "xxx"
@@ -761,7 +761,7 @@ func TestHTTP_Assign(t *testing.T) {
 
 		Convey("When I assign objects to a parent that has no ID", func() {
 
-			session := NewHTTPManipulator("username", "password", "http://fake.com", "")
+			session := NewHTTPManipulatorWithNamespace("username", "password", "http://fake.com", "")
 
 			l1 := NewList()
 			t2 := NewTask()
@@ -785,7 +785,7 @@ func TestHTTP_Assign(t *testing.T) {
 			}))
 			defer ts.Close()
 
-			session := NewHTTPManipulator("username", "password", ts.URL, "")
+			session := NewHTTPManipulatorWithNamespace("username", "password", ts.URL, "")
 
 			t1 := NewTask()
 			t1.ID = "xxx"
@@ -819,7 +819,7 @@ func TestHTTP_Count(t *testing.T) {
 			}))
 			defer ts.Close()
 
-			store := NewHTTPManipulator("username", "password", ts.URL, "")
+			store := NewHTTPManipulatorWithNamespace("username", "password", ts.URL, "")
 
 			ctx := manipulate.NewContext()
 			ctx.Parent = list
@@ -836,7 +836,7 @@ func TestHTTP_Count(t *testing.T) {
 
 		Convey("When I fetch its children but the parent has no ID", func() {
 
-			store := NewHTTPManipulator("username", "password", "http://fake.com", "")
+			store := NewHTTPManipulatorWithNamespace("username", "password", "http://fake.com", "")
 
 			list2 := NewList()
 
@@ -858,7 +858,7 @@ func TestHTTP_Count(t *testing.T) {
 			}))
 			defer ts.Close()
 
-			store := NewHTTPManipulator("username", "password", ts.URL, "")
+			store := NewHTTPManipulatorWithNamespace("username", "password", ts.URL, "")
 
 			ctx := manipulate.NewContext()
 			ctx.Parent = list
@@ -876,7 +876,7 @@ func TestHTTP_Increment(t *testing.T) {
 
 	Convey("Given I have a store", t, func() {
 
-		store := NewHTTPManipulator("username", "password", "", "")
+		store := NewHTTPManipulatorWithNamespace("username", "password", "", "")
 
 		Convey("When I call Count", func() {
 			err := store.Increment(nil, ListIdentity, "counter", 1)
@@ -893,7 +893,7 @@ func TestHTTP_send(t *testing.T) {
 
 	Convey("Given I have a store with bad url", t, func() {
 
-		store := NewHTTPManipulator("username", "password", "", "")
+		store := NewHTTPManipulatorWithNamespace("username", "password", "", "")
 
 		Convey("When I call send ", func() {
 

--- a/manipwebsocket/manipulator.go
+++ b/manipwebsocket/manipulator.go
@@ -55,11 +55,16 @@ func NewWebSocketManipulatorWithNamespace(username, password, url, namespace str
 		log.Error("Unable to load system root cert pool. tls fallback to unsecure.")
 	}
 
-	return NewWebSocketManipulatorWithRootCA(username, password, url, namespace, CAPool, true)
+	return NewWebSocketManipulatorWithRootCAAndNamespace(username, password, url, namespace, CAPool, true)
 }
 
 // NewWebSocketManipulatorWithRootCA returns a Manipulator backed by an ReST API using the given CAPool as root CA.
-func NewWebSocketManipulatorWithRootCA(username, password, url, namespace string, rootCAPool *x509.CertPool, skipTLSVerify bool) (manipulate.EventManipulator, func(), error) {
+func NewWebSocketManipulatorWithRootCA(username, password, url string, rootCAPool *x509.CertPool, skipTLSVerify bool) (manipulate.EventManipulator, func(), error) {
+	return NewWebSocketManipulatorWithRootCAAndNamespace(username, password, url, "", rootCAPool, skipTLSVerify)
+}
+
+// NewWebSocketManipulatorWithRootCAAndNamespace returns a Manipulator backed by an ReST API using the given CAPool as root CA.
+func NewWebSocketManipulatorWithRootCAAndNamespace(username, password, url, namespace string, rootCAPool *x509.CertPool, skipTLSVerify bool) (manipulate.EventManipulator, func(), error) {
 
 	tlsConfig := &tls.Config{
 		InsecureSkipVerify: skipTLSVerify,
@@ -108,7 +113,7 @@ func NewWebSocketManipulatorWithMidgardCertAuthentication(url string, midgardurl
 		return nil, nil, err
 	}
 
-	m, stop, err := NewWebSocketManipulatorWithRootCA("Bearer", token, url, namespace, rootCAPool, skipInsecure)
+	m, stop, err := NewWebSocketManipulatorWithRootCAAndNamespace("Bearer", token, url, namespace, rootCAPool, skipInsecure)
 	if err != nil {
 		return nil, nil, err
 	}


### PR DESCRIPTION
_This PR is a Work In Progress, please do not merge it yet :)_

Currently, `manipulate` force us to pass a `namespace` parameter while creating a `websocketManipulator` or an `httpManipulator`. Since this namespace is only valid for squall, we are trying to get rid of this unnecessary parameter.