### PR TITLE
New: Add debugging//tracing to Manipulate HTTP

### DIFF
--- a/maniphttp/manipulator.go
+++ b/maniphttp/manipulator.go
@@ -532,10 +532,18 @@ func (s *httpManipulator) send(request *http.Request, context *manipulate.Contex
 
 	s.prepareHeaders(request, context)
 
+	zap.L().Debug("Send request",
+		zap.Any("Header", request.Header),
+	)
+
 	response, err := s.client.Do(request)
 	if err != nil {
 		return response, manipulate.NewErrCannotCommunicate(sec.Snip(err, s.currentPassword()).Error())
 	}
+
+	zap.L().Debug("Receive response",
+		zap.Int("responseStatusCode", response.StatusCode),
+	)
 
 	if response.StatusCode < 200 || response.StatusCode >= 300 {
 


### PR DESCRIPTION
#### Description
WebSocket Manipulator allows to see every single request//response (Header and Body).
This PR plans to adapt HTTP Manip to bring the same capabilities