### PR TITLE
fixed: always close previous connection

### DIFF
--- a/internal/push/push.go
+++ b/internal/push/push.go
@@ -103,6 +103,10 @@ func (s *subscription) connect(ctx context.Context, initial bool) (err error) {
 			s.conn.Close(0)
 		}
 
+		if resp != nil {
+			resp.Body.Close() // nolint
+		}
+
 		if s.conn, resp, err = wsc.Connect(ctx, makeURL(s.url, s.ns, s.getCurrentToken(), s.recursive), s.config); err == nil {
 
 			if initial {
@@ -110,6 +114,8 @@ func (s *subscription) connect(ctx context.Context, initial bool) (err error) {
 			} else {
 				s.publishStatus(manipulate.SubscriberStatusReconnection)
 			}
+
+			resp.Body.Close() // nolint
 
 			try = 0
 			return nil


### PR DESCRIPTION
* fixes a potential memory leak when the main loop exists for other cause than a ws error
* fixes a potential memory leak where the body of the http request was not closed