### PR TITLE
Adapt reconcile

### DIFF
--- a/manipvortex/manipulator_test.go
+++ b/manipvortex/manipulator_test.go
@@ -476,11 +476,11 @@ func Test_Create(t *testing.T) {
 
 		objConfig := v.(*vortexManipulator).processors[testmodel.ListIdentity.Name]
 		objConfig.UpstreamReconciler = NewTestReconciler()
-		objConfig.UpstreamReconciler.(TestReconciler).MockReconcile(t, func(mctx manipulate.Context, op elemental.Operation, i *elemental.Identifiable) (bool, error) {
+		objConfig.UpstreamReconciler.(TestReconciler).MockReconcile(t, func(mctx manipulate.Context, op elemental.Operation, i elemental.Identifiable) (elemental.Identifiable, bool, error) {
 			if mctx.Parent() != nil {
-				return false, nil
+				return i, false, nil
 			}
-			return true, nil
+			return i, true, nil
 		})
 
 		Convey("When I create objects", func() {
@@ -508,8 +508,8 @@ func Test_Create(t *testing.T) {
 
 			Convey("When the backend succeeds, the object must not be stored in the DB if accepter did not accept", func() {
 
-				a.MockReconcile(t, func(manipulate.Context, elemental.Operation, *elemental.Identifiable) (bool, error) {
-					return false, nil
+				a.MockReconcile(t, func(manipulate.Context, elemental.Operation, elemental.Identifiable) (elemental.Identifiable, bool, error) {
+					return nil, false, nil
 				})
 
 				m.MockCreate(t, func(mctx manipulate.Context, object elemental.Identifiable) error {
@@ -598,11 +598,11 @@ func Test_Update(t *testing.T) {
 
 		objConfig := v.(*vortexManipulator).processors[testmodel.ListIdentity.Name]
 		objConfig.UpstreamReconciler = NewTestReconciler()
-		objConfig.UpstreamReconciler.(TestReconciler).MockReconcile(t, func(mctx manipulate.Context, op elemental.Operation, i *elemental.Identifiable) (bool, error) {
+		objConfig.UpstreamReconciler.(TestReconciler).MockReconcile(t, func(mctx manipulate.Context, op elemental.Operation, i elemental.Identifiable) (elemental.Identifiable, bool, error) {
 			if mctx.Parent() != nil {
-				return false, nil
+				return i, false, nil
 			}
-			return true, nil
+			return i, true, nil
 		})
 
 		obj := newObject("obj1", []string{"label"})
@@ -640,8 +640,8 @@ func Test_Update(t *testing.T) {
 
 			Convey("When the backend succeeds, the object must not be stored in the DB if accepter did not accept", func() {
 
-				a.MockReconcile(t, func(manipulate.Context, elemental.Operation, *elemental.Identifiable) (bool, error) {
-					return false, nil
+				a.MockReconcile(t, func(ctx manipulate.Context, op elemental.Operation, obj elemental.Identifiable) (elemental.Identifiable, bool, error) {
+					return obj, false, nil
 				})
 
 				m.MockUpdate(t, func(mctx manipulate.Context, object elemental.Identifiable) error {
@@ -730,11 +730,11 @@ func Test_Delete(t *testing.T) {
 
 		objConfig := v.(*vortexManipulator).processors[testmodel.ListIdentity.Name]
 		objConfig.UpstreamReconciler = NewTestReconciler()
-		objConfig.UpstreamReconciler.(TestReconciler).MockReconcile(t, func(mctx manipulate.Context, op elemental.Operation, i *elemental.Identifiable) (bool, error) {
+		objConfig.UpstreamReconciler.(TestReconciler).MockReconcile(t, func(mctx manipulate.Context, op elemental.Operation, i elemental.Identifiable) (elemental.Identifiable, bool, error) {
 			if mctx.Parent() != nil {
-				return false, nil
+				return i, false, nil
 			}
-			return true, nil
+			return i, true, nil
 		})
 
 		obj := newObject("obj1", []string{"label"})
@@ -770,8 +770,8 @@ func Test_Delete(t *testing.T) {
 
 			Convey("When the backend succeeds, the object must not be deleted in the DB if accepter did not accept", func() {
 
-				a.MockReconcile(t, func(manipulate.Context, elemental.Operation, *elemental.Identifiable) (bool, error) {
-					return false, nil
+				a.MockReconcile(t, func(_ manipulate.Context, _ elemental.Operation, obj elemental.Identifiable) (elemental.Identifiable, bool, error) {
+					return obj, false, nil
 				})
 
 				m.MockDelete(t, func(mctx manipulate.Context, object elemental.Identifiable) error {
@@ -1186,8 +1186,8 @@ func Test_Monitor(t *testing.T) {
 
 		Convey("When I push a create event, the object must not be written in the DB when accepter rejects it", func() {
 
-			a.MockReconcile(t, func(manipulate.Context, elemental.Operation, *elemental.Identifiable) (bool, error) {
-				return false, nil
+			a.MockReconcile(t, func(_ manipulate.Context, _ elemental.Operation, obj elemental.Identifiable) (elemental.Identifiable, bool, error) {
+				return obj, false, nil
 			})
 
 			obj := newObject("push1", []string{"test=push"})

--- a/manipvortex/reconciler.go
+++ b/manipvortex/reconciler.go
@@ -17,18 +17,18 @@ type Reconciler interface {
 	// false, the objects are ignored.
 	// If it returns an error, the error will be forwarded to the caller.
 	// The Reconcile function may modify the objects to perform transformations.
-	Reconcile(manipulate.Context, elemental.Operation, *elemental.Identifiable) (bool, error)
+	Reconcile(manipulate.Context, elemental.Operation, elemental.Identifiable) (elemental.Identifiable, bool, error)
 }
 
 // A TestReconciler is an Reconciler that can be used for
 // testing purposes.
 type TestReconciler interface {
 	Reconciler
-	MockReconcile(t *testing.T, impl func(manipulate.Context, elemental.Operation, *elemental.Identifiable) (bool, error))
+	MockReconcile(t *testing.T, impl func(manipulate.Context, elemental.Operation, elemental.Identifiable) (elemental.Identifiable, bool, error))
 }
 
 type mockedReconcilerMethods struct {
-	reconcileMock func(manipulate.Context, elemental.Operation, *elemental.Identifiable) (bool, error)
+	reconcileMock func(manipulate.Context, elemental.Operation, elemental.Identifiable) (elemental.Identifiable, bool, error)
 }
 
 type testReconciler struct {
@@ -46,16 +46,16 @@ func NewTestReconciler() TestReconciler {
 }
 
 // MockPrefetch sets the mocked implementation of Reconcile.
-func (p *testReconciler) MockReconcile(t *testing.T, impl func(manipulate.Context, elemental.Operation, *elemental.Identifiable) (bool, error)) {
+func (p *testReconciler) MockReconcile(t *testing.T, impl func(manipulate.Context, elemental.Operation, elemental.Identifiable) (elemental.Identifiable, bool, error)) {
 	p.currentMocks(t).reconcileMock = impl
 }
 
-func (p *testReconciler) Reconcile(mctx manipulate.Context, op elemental.Operation, i *elemental.Identifiable) (bool, error) {
+func (p *testReconciler) Reconcile(mctx manipulate.Context, op elemental.Operation, i elemental.Identifiable) (elemental.Identifiable, bool, error) {
 	if mock := p.currentMocks(p.currentTest); mock != nil && mock.reconcileMock != nil {
 		return mock.reconcileMock(mctx, op, i)
 	}
 
-	return true, nil
+	return i, true, nil
 }
 
 func (p *testReconciler) currentMocks(t *testing.T) *mockedReconcilerMethods {

--- a/manipvortex/reconciler_test.go
+++ b/manipvortex/reconciler_test.go
@@ -24,7 +24,7 @@ func TestTestReconciler(t *testing.T) {
 
 		Convey("When I call the Accept method without mock", func() {
 
-			ok, err := r.Reconcile(manipulate.NewContext(context.Background()), elemental.OperationCreate, nil)
+			obj, ok, err := r.Reconcile(manipulate.NewContext(context.Background()), elemental.OperationCreate, nil)
 
 			Convey("Then err should be nil", func() {
 				So(err, ShouldBeNil)
@@ -33,15 +33,19 @@ func TestTestReconciler(t *testing.T) {
 			Convey("Then ok should be true", func() {
 				So(ok, ShouldBeTrue)
 			})
+
+			Convey("The object should be nil", func() {
+				So(obj, ShouldBeNil)
+			})
 		})
 
 		Convey("When I call the Accept method with a mock", func() {
 
-			r.MockReconcile(t, func(manipulate.Context, elemental.Operation, *elemental.Identifiable) (bool, error) {
-				return false, fmt.Errorf("boom")
+			r.MockReconcile(t, func(_ manipulate.Context, _ elemental.Operation, obj elemental.Identifiable) (elemental.Identifiable, bool, error) {
+				return obj, false, fmt.Errorf("boom")
 			})
 
-			ok, err := r.Reconcile(manipulate.NewContext(context.Background()), elemental.OperationCreate, nil)
+			obj, ok, err := r.Reconcile(manipulate.NewContext(context.Background()), elemental.OperationCreate, nil)
 
 			Convey("Then err should not be nil", func() {
 				So(err, ShouldNotBeNil)
@@ -51,6 +55,11 @@ func TestTestReconciler(t *testing.T) {
 			Convey("Then ok should be false", func() {
 				So(ok, ShouldBeFalse)
 			})
+
+			Convey("The object should be nil", func() {
+				So(obj, ShouldBeNil)
+			})
+
 		})
 	})
 }


### PR DESCRIPTION
Changes the signature of the Reconcile method in order to allow reconciles to change the type of object provided in the interface.