### PR TITLE
Allow per-context delegation token override

### DIFF
--- a/context.go
+++ b/context.go
@@ -62,7 +62,7 @@ type Context interface {
 	Override() bool
 	Recursive() bool
 	Namespace() string
-	DelegationToken() string
+	Credentials() (string, string)
 	Parameters() url.Values
 	Parent() elemental.Identifiable
 	ExternalTrackingID() string
@@ -121,7 +121,8 @@ type mcontext struct {
 	readConsistency      ReadConsistency
 	messages             []string
 	idempotencyKey       string
-	delegationToken      string
+	username             string
+	password             string
 }
 
 // Count returns the count
@@ -199,10 +200,13 @@ func (c *mcontext) IdempotencyKey() string { return c.idempotencyKey }
 func (c *mcontext) SetIdempotencyKey(k string) { c.idempotencyKey = k }
 
 // DelegationToken returns any delegation token provided by options.
-func (c *mcontext) DelegationToken() string { return c.delegationToken }
+func (c *mcontext) Credentials() (string, string) { return c.username, c.password }
 
 // SetDelegationToken sets the delegation token for this context.
-func (c *mcontext) SetDelegationToken(t string) { c.delegationToken = t }
+func (c *mcontext) SetCredentials(username, password string) {
+	c.username = username
+	c.password = password
+}
 
 // String returns the string representation of the Context.
 func (c *mcontext) String() string {
@@ -231,7 +235,8 @@ func (c *mcontext) Derive(options ...ContextOption) Context {
 		order:                c.order,
 		fields:               c.fields,
 		ctx:                  c.ctx,
-		delegationToken:      c.delegationToken,
+		username:             c.username,
+		password:             c.password,
 	}
 
 	for _, opt := range options {

--- a/context.go
+++ b/context.go
@@ -62,6 +62,7 @@ type Context interface {
 	Override() bool
 	Recursive() bool
 	Namespace() string
+	DelegationToken() string
 	Parameters() url.Values
 	Parent() elemental.Identifiable
 	ExternalTrackingID() string
@@ -120,6 +121,7 @@ type mcontext struct {
 	readConsistency      ReadConsistency
 	messages             []string
 	idempotencyKey       string
+	delegationToken      string
 }
 
 // Count returns the count
@@ -196,6 +198,12 @@ func (c *mcontext) IdempotencyKey() string { return c.idempotencyKey }
 // by manipulator implementation supporting it.
 func (c *mcontext) SetIdempotencyKey(k string) { c.idempotencyKey = k }
 
+// DelegationToken returns any delegation token provided by options.
+func (c *mcontext) DelegationToken() string { return c.delegationToken }
+
+// SetDelegationToken sets the delegation token for this context.
+func (c *mcontext) SetDelegationToken(t string) { c.delegationToken = t }
+
 // String returns the string representation of the Context.
 func (c *mcontext) String() string {
 
@@ -223,6 +231,7 @@ func (c *mcontext) Derive(options ...ContextOption) Context {
 		order:                c.order,
 		fields:               c.fields,
 		ctx:                  c.ctx,
+		delegationToken:      c.delegationToken,
 	}
 
 	for _, opt := range options {

--- a/maniphttp/manipulator.go
+++ b/maniphttp/manipulator.go
@@ -399,9 +399,9 @@ func (s *httpManipulator) Count(mctx manipulate.Context, identity elemental.Iden
 	return mctx.Count(), nil
 }
 
-func (s *httpManipulator) makeAuthorizationHeaders() string {
+func (s *httpManipulator) makeAuthorizationHeaders(password string) string {
 
-	return s.username + " " + s.currentPassword()
+	return s.username + " " + password
 }
 
 func (s *httpManipulator) prepareHeaders(request *http.Request, mctx manipulate.Context) {
@@ -423,8 +423,13 @@ func (s *httpManipulator) prepareHeaders(request *http.Request, mctx manipulate.
 		request.Header.Set("X-Namespace", ns)
 	}
 
-	if s.username != "" && s.currentPassword() != "" {
-		request.Header.Set("Authorization", s.makeAuthorizationHeaders())
+	password := mctx.DelegationToken()
+	if password == "" {
+		password = s.currentPassword()
+	}
+
+	if s.username != "" && password != "" {
+		request.Header.Set("Authorization", s.makeAuthorizationHeaders(password))
 	}
 
 	if v := mctx.ExternalTrackingID(); v != "" {

--- a/maniphttp/manipulator.go
+++ b/maniphttp/manipulator.go
@@ -399,9 +399,9 @@ func (s *httpManipulator) Count(mctx manipulate.Context, identity elemental.Iden
 	return mctx.Count(), nil
 }
 
-func (s *httpManipulator) makeAuthorizationHeaders(password string) string {
+func (s *httpManipulator) makeAuthorizationHeaders(username, password string) string {
 
-	return s.username + " " + password
+	return username + " " + password
 }
 
 func (s *httpManipulator) prepareHeaders(request *http.Request, mctx manipulate.Context) {
@@ -423,13 +423,17 @@ func (s *httpManipulator) prepareHeaders(request *http.Request, mctx manipulate.
 		request.Header.Set("X-Namespace", ns)
 	}
 
-	password := mctx.DelegationToken()
+	username, password := mctx.Credentials()
 	if password == "" {
 		password = s.currentPassword()
 	}
 
-	if s.username != "" && password != "" {
-		request.Header.Set("Authorization", s.makeAuthorizationHeaders(password))
+	if s.username == "" {
+		username = s.username
+	}
+
+	if username != "" && password != "" {
+		request.Header.Set("Authorization", s.makeAuthorizationHeaders(username, password))
 	}
 
 	if v := mctx.ExternalTrackingID(); v != "" {

--- a/maniphttp/manipulator_test.go
+++ b/maniphttp/manipulator_test.go
@@ -117,6 +117,7 @@ func TestHTTP_prepareHeaders(t *testing.T) {
 					manipulate.ContextOptionReadConsistency(manipulate.ReadConsistencyStrong),
 					manipulate.ContextOptionWriteConsistency(manipulate.WriteConsistencyStrong),
 					manipulate.ContextOptionFields([]string{"a", "b"}),
+					manipulate.ContextOptionCredentials("username", "password"),
 				)
 
 				ctx.(idempotency.Keyer).SetIdempotencyKey("coucou")
@@ -145,6 +146,10 @@ func TestHTTP_prepareHeaders(t *testing.T) {
 
 				Convey("Then I should have a value for X-Fields", func() {
 					So(req.Header["X-Fields"], ShouldResemble, []string{"a", "b"})
+				})
+
+				Convey("Then I should have a value for the Authorization", func() {
+					So(req.Header.Get("Authorization"), ShouldResemble, "username password")
 				})
 			})
 		})

--- a/maniphttp/manipulator_test.go
+++ b/maniphttp/manipulator_test.go
@@ -67,7 +67,7 @@ func TestHTTP_makeAuthorizationHeaders(t *testing.T) {
 		Convey("When I prepare the Authorization", func() {
 
 			m := NewHTTPManipulator("http://url.com", "username", "password", "").(*httpManipulator)
-			h := m.makeAuthorizationHeaders("password")
+			h := m.makeAuthorizationHeaders("username", "password")
 
 			Convey("Then the header should be correct", func() {
 				So(h, ShouldEqual, "username password")

--- a/maniphttp/manipulator_test.go
+++ b/maniphttp/manipulator_test.go
@@ -67,7 +67,7 @@ func TestHTTP_makeAuthorizationHeaders(t *testing.T) {
 		Convey("When I prepare the Authorization", func() {
 
 			m := NewHTTPManipulator("http://url.com", "username", "password", "").(*httpManipulator)
-			h := m.makeAuthorizationHeaders()
+			h := m.makeAuthorizationHeaders("password")
 
 			Convey("Then the header should be correct", func() {
 				So(h, ShouldEqual, "username password")

--- a/options.go
+++ b/options.go
@@ -136,9 +136,9 @@ func ContextOptionCredentials(username, password string) ContextOption {
 }
 
 // ContextOptionToken sets the token for this request.
-func ContextOptionToken(username, password string) ContextOption {
+func ContextOptionToken(token string) ContextOption {
 	return func(c *mcontext) {
 		c.username = "Bearer"
-		c.password = password
+		c.password = token
 	}
 }

--- a/options.go
+++ b/options.go
@@ -127,9 +127,18 @@ func ContextOptionReadConsistency(consistency ReadConsistency) ContextOption {
 	}
 }
 
-// ContextOptionDelegationToken sets the desired read consistency of the request.
-func ContextOptionDelegationToken(token string) ContextOption {
+// ContextOptionCredentials sets user name and password for this context.
+func ContextOptionCredentials(username, password string) ContextOption {
 	return func(c *mcontext) {
-		c.delegationToken = token
+		c.username = username
+		c.password = password
+	}
+}
+
+// ContextOptionToken sets the token for this request.
+func ContextOptionToken(username, password string) ContextOption {
+	return func(c *mcontext) {
+		c.username = "Bearer"
+		c.password = password
 	}
 }

--- a/options.go
+++ b/options.go
@@ -126,3 +126,10 @@ func ContextOptionReadConsistency(consistency ReadConsistency) ContextOption {
 		c.readConsistency = consistency
 	}
 }
+
+// ContextOptionDelegationToken sets the desired read consistency of the request.
+func ContextOptionDelegationToken(token string) ContextOption {
+	return func(c *mcontext) {
+		c.delegationToken = token
+	}
+}

--- a/options_test.go
+++ b/options_test.go
@@ -104,4 +104,19 @@ func TestManipulate_ContextOption(t *testing.T) {
 		ContextOptionReadConsistency(ReadConsistencyStrong)(mctx.(*mcontext))
 		So(mctx.ReadConsistency(), ShouldEqual, ReadConsistencyStrong)
 	})
+
+	Convey("Calling ContextOptionCredentials should work", t, func() {
+		ContextOptionCredentials("username", "password")(mctx.(*mcontext))
+		u, p := mctx.Credentials()
+		So(u, ShouldResemble, "username")
+		So(p, ShouldResemble, "password")
+	})
+
+	Convey("Calling ContextOptionToken should work", t, func() {
+		ContextOptionToken("token")(mctx.(*mcontext))
+		u, p := mctx.Credentials()
+		So(u, ShouldResemble, "Bearer")
+		So(p, ShouldResemble, "token")
+	})
+
 }


### PR DESCRIPTION
This PR allows callers to provide an API token per call and override the default API token that is resolved in the manipulator. This allows the manipulator to make calls on behalf of other users.