### PR TITLE
fixed: deadlock in flush

### DIFF
--- a/manipvortex/manipulator.go
+++ b/manipvortex/manipulator.go
@@ -142,8 +142,8 @@ func New(
 // db.
 func (m *vortexManipulator) Flush(ctx context.Context) error {
 
-	m.Lock()
-	defer m.Unlock()
+	m.RLock()
+	defer m.RUnlock()
 
 	if m.prefetcher != nil {
 		m.prefetcher.Flush()


### PR DESCRIPTION

this patches fixes a dead lock when Flush is called while the manipulator has a prefetcher