### PR TITLE
new/maniphttp: add option to simulate failure

### DIFF
--- a/maniphttp/manipulator.go
+++ b/maniphttp/manipulator.go
@@ -19,6 +19,7 @@ import (
 	"fmt"
 	"io"
 	"io/ioutil"
+	"math/rand"
 	"net"
 	"net/http"
 	"net/url"
@@ -54,6 +55,7 @@ type httpManipulator struct {
 	disableCompression   bool
 	defaultRetryFunc     manipulate.RetryFunc
 	atomicRenewTokenFunc func(context.Context) error
+	failureSimulations   map[float64]error
 
 	// optionnable
 	ctx           context.Context
@@ -551,6 +553,14 @@ func (s *httpManipulator) send(
 	dest interface{},
 	sp opentracing.Span,
 ) (*http.Response, error) {
+
+	if len(s.failureSimulations) > 0 {
+		for chance, err := range s.failureSimulations {
+			if rand.Float64() < chance {
+				return nil, err
+			}
+		}
+	}
 
 	var try int         // try number. Starts at 0
 	var lastError error // last error before retry.

--- a/maniphttp/manipulator_test.go
+++ b/maniphttp/manipulator_test.go
@@ -1592,6 +1592,61 @@ func TestHTTP_send(t *testing.T) {
 			})
 		})
 	})
+
+	Convey("Given I have a server returning 201 but a simulation error with 100% chance", t, func() {
+
+		m, _ := New(context.Background(), "toto.com", OptionSimulateFailures(
+			map[float64]error{
+				1.0: fmt.Errorf("simulated error"),
+			},
+		))
+
+		ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			panic("this should not be called")
+		}))
+		defer ts.Close()
+
+		Convey("When I call send", func() {
+
+			ctx, cancel := context.WithTimeout(context.Background(), 15*time.Second)
+			defer cancel()
+
+			resp, err := m.(*httpManipulator).send(manipulate.NewContext(ctx), http.MethodPost, ts.URL, nil, nil, sp)
+
+			Convey("Then err should not be nil", func() {
+				So(err, ShouldNotBeNil)
+				So(err.Error(), ShouldEqual, "simulated error")
+				So(resp, ShouldBeNil)
+			})
+		})
+	})
+
+	Convey("Given I have a server returning 201 but a simulation error with 0% chance", t, func() {
+
+		m, _ := New(context.Background(), "toto.com", OptionSimulateFailures(
+			map[float64]error{
+				0.0: fmt.Errorf("simulated error"),
+			},
+		))
+
+		ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			w.WriteHeader(http.StatusNoContent)
+		}))
+		defer ts.Close()
+
+		Convey("When I call send", func() {
+
+			ctx, cancel := context.WithTimeout(context.Background(), 15*time.Second)
+			defer cancel()
+
+			resp, err := m.(*httpManipulator).send(manipulate.NewContext(ctx), http.MethodPost, ts.URL, nil, nil, sp)
+
+			Convey("Then err should be nil", func() {
+				So(err, ShouldBeNil)
+				So(resp, ShouldNotBeNil)
+			})
+		})
+	})
 }
 
 func TestHTTP_makeAuthorizationHeaders(t *testing.T) {

--- a/maniphttp/options.go
+++ b/maniphttp/options.go
@@ -124,3 +124,25 @@ func OptionDisableCompression() Option {
 		m.disableCompression = true
 	}
 }
+
+// OptionSimulateFailures will inject random http codes in
+// normal operations.
+// The key of the map is a float between 0 and 1 that will
+// give the percentage of chance for simulating the failure,
+// and error it should return.
+//
+// For instance, take the following map:
+//      map[float64]error{
+//          0.10: manipulate.NewErrCannotBuildQuery("oh no"),
+//          0.25: manipulate.NewErrCannotCommunicate("service is gone"),
+//      }
+//
+// It will return manipulate.NewErrCannotBuildQuery around 10% of the requests,
+// manipulate.NewErrCannotCommunicate around 25% of the requests.
+// This is obviously designed for simulating backend failures and should
+// not be used in production, obviously.
+func OptionSimulateFailures(failureSimulations map[float64]error) Option {
+	return func(m *httpManipulator) {
+		m.failureSimulations = failureSimulations
+	}
+}

--- a/maniphttp/options_test.go
+++ b/maniphttp/options_test.go
@@ -108,4 +108,11 @@ func TestManipHttp_Optionions(t *testing.T) {
 		OptionDisableCompression()(m)
 		So(m.disableCompression, ShouldEqual, true)
 	})
+
+	Convey("Calling OptionSimulateFailures should work", t, func() {
+		m := &httpManipulator{}
+		f := map[float64]error{}
+		OptionSimulateFailures(f)(m)
+		So(m.failureSimulations, ShouldEqual, f)
+	})
 }


### PR DESCRIPTION

This patch adds the option OptionSimulateFailures to inject random failure in the low level communication process.