### PR TITLE
Fix the manipulator retries on forbidden/unauthorized

### DIFF
--- a/maniphttp/manipulator.go
+++ b/maniphttp/manipulator.go
@@ -552,8 +552,9 @@ func (s *httpManipulator) send(
 	sp opentracing.Span,
 ) (*http.Response, error) {
 
-	var try int         // try number. Starts at 0
-	var lastError error // last error before retry.
+	var try int               // try number. Starts at 0
+	var lastError error       // last error before retry.
+	var tokenRenewedOnce bool // after an authorization failures token is renewed at most once.
 
 	// We get the context deadline.
 	deadline, ok := mctx.Context().Deadline()
@@ -701,7 +702,7 @@ func (s *httpManipulator) send(
 				return nil, err
 			}
 
-			if s.tokenManager != nil && (response.StatusCode == http.StatusForbidden || response.StatusCode == http.StatusUnauthorized) {
+			if !tokenRenewedOnce && s.tokenManager != nil && (response.StatusCode == http.StatusForbidden || response.StatusCode == http.StatusUnauthorized) {
 
 				// This is a special case where we try to renew our token
 				// in case of 401 or 403 error.
@@ -713,6 +714,7 @@ func (s *httpManipulator) send(
 					err := s.atomicRenewTokenFunc(mctx.Context())
 					if err == nil {
 						lastError = errs
+						tokenRenewedOnce = true
 						goto RETRY
 					}
 				}


### PR DESCRIPTION
The retry logic will essentially retry for ever if it is forbidden/unauthorized. It will renew the token and jump to retry that will start everything again. 

The change limits the number of retry attempt to a maximum of 2. 