### PR TITLE
Fix crash in vortex subscriber when there is no filter

### DIFF
--- a/manipvortex/manipulator.go
+++ b/manipvortex/manipulator.go
@@ -701,10 +701,15 @@ func (m *vortexManipulator) pushEvent(evt *elemental.Event) {
 	m.RLock()
 	defer m.RUnlock()
 
+	var isFiltered bool
+
 	for _, s := range m.subscribers {
 
 		s.RLock()
-		isFiltered := s.filter.IsFilteredOut(evt.Identity, evt.Type)
+		isFiltered = false
+		if s.filter != nil {
+			isFiltered = s.filter.IsFilteredOut(evt.Identity, evt.Type)
+		}
 		s.RUnlock()
 
 		if !isFiltered {


### PR DESCRIPTION
Fixes the crash in vortex manipulator where it was assuming that the filter is always not nil.