### PR TITLE
Fixed: remove race around bodyCloser when no content

### DIFF
--- a/maniphttp/manipulator.go
+++ b/maniphttp/manipulator.go
@@ -739,7 +739,13 @@ func (s *httpManipulator) send(
 
 		// If we have content, we return the response.
 		// The body will be drained by the defered call to closeCurrentBody().
-		if response.StatusCode == http.StatusNoContent || response.ContentLength == 0 || dest == nil {
+		if response.StatusCode == http.StatusNoContent || response.ContentLength == 0 {
+			bodyCloser = nil
+
+			return response, nil
+		}
+
+		if dest == nil {
 			return response, nil
 		}
 


### PR DESCRIPTION
#### Description
This PR will aim to fix the following data race:
```
==================
WARNING: DATA RACE
Read at 0x00c0027b1710 by goroutine 227:
  bytes.(*Buffer).Read()
      /usr/local/go/src/bytes/buffer.go:72 +0x60
  io/ioutil.(*nopCloser).Read()
      <autogenerated>:1 +0x87
  net/http.transferBodyReader.Read()
      /usr/local/go/src/net/http/transfer.go:62 +0x77
  io.(*LimitedReader).Read()
      /usr/local/go/src/io/io.go:448 +0xc7
  bufio.(*Writer).ReadFrom()
      /usr/local/go/src/bufio/bufio.go:722 +0x13b
  io.copyBuffer()
      /usr/local/go/src/io/io.go:388 +0x3fa
  net/http.(*transferWriter).writeBody()
      /usr/local/go/src/io/io.go:364 +0xc3f
  net/http.(*Request).write()
      /usr/local/go/src/net/http/request.go:655 +0x85e
  net/http.(*persistConn).writeLoop()
      /usr/local/go/src/net/http/transport.go:1979 +0x321

Previous write at 0x00c0027b1710 by goroutine 63:
  bytes.(*Buffer).Read()
      /usr/local/go/src/bytes/buffer.go:101 +0xb5
  io/ioutil.(*nopCloser).Read()
      <autogenerated>:1 +0x87
  io/ioutil.devNull.ReadFrom()
      /usr/local/go/src/io/ioutil/ioutil.go:147 +0xb9
  io/ioutil.(*devNull).ReadFrom()
      <autogenerated>:1 +0x7c
  io.copyBuffer()
      /usr/local/go/src/io/io.go:388 +0x3fa
  go.aporeto.io/backend/vendor/go.aporeto.io/manipulate/maniphttp.(*httpManipulator).send.func2()
      /usr/local/go/src/io/io.go:364 +0xf9
  go.aporeto.io/backend/vendor/go.aporeto.io/manipulate/maniphttp.(*httpManipulator).send()
      /tmp/build/ae5c2d4a/go/src/go.aporeto.io/backend/vendor/go.aporeto.io/manipulate/maniphttp/manipulator.go:743 +0x1422
  go.aporeto.io/backend/vendor/go.aporeto.io/manipulate/maniphttp.(*httpManipulator).Create()
      /tmp/build/ae5c2d4a/go/src/go.aporeto.io/backend/vendor/go.aporeto.io/manipulate/maniphttp/manipulator.go:263 +0x633
  go.aporeto.io/backend/internal/tagutils.(*Batcher).handleTags.func1()
      /tmp/build/ae5c2d4a/go/src/go.aporeto.io/backend/internal/tagutils/batcher.go:108 +0x41f
  go.aporeto.io/backend/internal/tagutils.(*Batcher).handleTags()
      /tmp/build/ae5c2d4a/go/src/go.aporeto.io/backend/internal/tagutils/batcher.go:147 +0x449

Goroutine 227 (running) created at:
  net/http.(*Transport).dialConn()
      /usr/local/go/src/net/http/transport.go:1358 +0xc57
  net/http.(*Transport).getConn.func4()
      /usr/local/go/src/net/http/transport.go:1015 +0xd0

Goroutine 63 (running) created at:
  go.aporeto.io/backend/internal/tagutils.(*Batcher).Start()
      /tmp/build/ae5c2d4a/go/src/go.aporeto.io/backend/internal/tagutils/batcher.go:52 +0x68
  go.aporeto.io/backend/internal/bootstrap.MakeTagsInjector()
      /tmp/build/ae5c2d4a/go/src/go.aporeto.io/backend/internal/bootstrap/crud.go:25 +0x114
  go.aporeto.io/backend/srv/squall.Start()
      /tmp/build/ae5c2d4a/go/src/go.aporeto.io/backend/srv/squall/main.go:72 +0xcc3
  main.start()
      /tmp/build/ae5c2d4a/go/src/go.aporeto.io/backend/services.go:85 +0x558
  main.main()
      /tmp/build/ae5c2d4a/go/src/go.aporeto.io/backend/main.go:18 +0x4d
==================
```