### PR TITLE
new: added opaque data in manipulate.Context

### DIFF
--- a/context_test.go
+++ b/context_test.go
@@ -147,6 +147,7 @@ func TestContext_Derive(t *testing.T) {
 			readConsistency:      ReadConsistencyMonotonic,
 			clientIP:             "1.1.1.1",
 			retryRatio:           12,
+			opaque:               map[string]interface{}{"a": "b"},
 		}
 
 		mctx.SetCount(3)
@@ -172,15 +173,18 @@ func TestContext_Derive(t *testing.T) {
 				So(copy.ExternalTrackingID(), ShouldEqual, mctx.externalTrackingID)
 				So(copy.ExternalTrackingType(), ShouldEqual, mctx.externalTrackingType)
 				So(copy.Fields(), ShouldResemble, mctx.fields)
+				So(copy.Fields(), ShouldNotEqual, mctx.fields)
 				So(copy.Filter().String(), ShouldEqual, `k == "v"`)
 				So(copy.Finalizer(), ShouldEqual, mctx.createFinalizer)
 				So(copy.Namespace(), ShouldEqual, mctx.namespace)
 				So(copy.Order(), ShouldResemble, mctx.order)
+				So(copy.Order(), ShouldNotEqual, mctx.order)
 				So(copy.Override(), ShouldEqual, mctx.overrideProtection)
 				So(copy.Page(), ShouldEqual, mctx.page)
 				So(copy.PageSize(), ShouldEqual, mctx.pageSize)
 				So(copy.After(), ShouldEqual, mctx.after)
-				So(copy.Parameters(), ShouldEqual, mctx.parameters)
+				So(copy.Parameters(), ShouldResemble, mctx.parameters)
+				So(copy.Parameters(), ShouldNotEqual, mctx.parameters)
 				So(copy.Parent(), ShouldEqual, mctx.parent)
 				So(copy.password, ShouldEqual, mctx.password)
 				So(copy.ReadConsistency(), ShouldEqual, mctx.readConsistency)
@@ -193,6 +197,8 @@ func TestContext_Derive(t *testing.T) {
 				So(copy.WriteConsistency(), ShouldEqual, mctx.writeConsistency)
 				So(copy.Context(), ShouldEqual, mctx.ctx)
 				So(copy.RetryRatio(), ShouldEqual, mctx.retryRatio)
+				So(copy.Opaque(), ShouldResemble, mctx.opaque)
+				So(copy.Opaque(), ShouldNotEqual, mctx.opaque)
 			})
 		})
 
@@ -217,11 +223,14 @@ func TestContext_Derive(t *testing.T) {
 				So(copy.ExternalTrackingID(), ShouldEqual, mctx.externalTrackingID)
 				So(copy.ExternalTrackingType(), ShouldEqual, mctx.externalTrackingType)
 				So(copy.Fields(), ShouldResemble, mctx.fields)
+				So(copy.Fields(), ShouldNotEqual, mctx.fields)
 				So(copy.Finalizer(), ShouldEqual, mctx.createFinalizer)
 				So(copy.Namespace(), ShouldEqual, mctx.namespace)
 				So(copy.Order(), ShouldResemble, mctx.order)
+				So(copy.Order(), ShouldNotEqual, mctx.order)
 				So(copy.Override(), ShouldEqual, mctx.overrideProtection)
-				So(copy.Parameters(), ShouldEqual, mctx.parameters)
+				So(copy.Parameters(), ShouldResemble, mctx.parameters)
+				So(copy.Parameters(), ShouldNotEqual, mctx.parameters)
 				So(copy.Parent(), ShouldEqual, mctx.parent)
 				So(copy.password, ShouldEqual, mctx.password)
 				So(copy.ReadConsistency(), ShouldEqual, mctx.readConsistency)
@@ -233,6 +242,8 @@ func TestContext_Derive(t *testing.T) {
 				So(copy.WriteConsistency(), ShouldEqual, mctx.writeConsistency)
 				So(copy.Context(), ShouldEqual, mctx.ctx)
 				So(copy.RetryRatio(), ShouldEqual, mctx.retryRatio)
+				So(copy.Opaque(), ShouldResemble, mctx.opaque)
+				So(copy.Opaque(), ShouldNotEqual, mctx.opaque)
 			})
 		})
 	})

--- a/maniphttp/options_test.go
+++ b/maniphttp/options_test.go
@@ -27,7 +27,7 @@ type testTokenManager struct{}
 func (t *testTokenManager) Issue(context.Context) (string, error)        { return "", nil }
 func (t *testTokenManager) Run(ctx context.Context, tokenCh chan string) {}
 
-func TestManipHttp_Optionions(t *testing.T) {
+func Test_Options(t *testing.T) {
 
 	Convey("Calling OptionCredentials should work", t, func() {
 		m := &httpManipulator{}

--- a/manipmongo/manipulator.go
+++ b/manipmongo/manipulator.go
@@ -369,15 +369,63 @@ func (m *mongoManipulator) Create(mctx manipulate.Context, object elemental.Iden
 		}
 	}
 
-	if _, err := RunQuery(
-		mctx,
-		func() (interface{}, error) { return nil, c.Insert(object) },
-		RetryInfo{
-			Operation:        elemental.OperationCreate,
-			Identity:         object.Identity(),
-			defaultRetryFunc: m.defaultRetryFunc,
-		},
-	); err != nil {
+	var err error
+	if operations, upsert := mctx.(opaquer).Opaque()[opaqueKeyUpsert]; upsert {
+
+		id := object.Identifier()
+		object.SetIdentifier("")
+
+		ops, ok := operations.(bson.M)
+		if !ok {
+			return manipulate.NewErrCannotBuildQuery("Upsert operations must be of type bson.M")
+		}
+
+		baseOps := bson.M{
+			"$set":         object,
+			"$setOnInsert": bson.M{"_id": id},
+		}
+
+		if len(ops) > 0 {
+
+			if soi, ok := ops["$setOnInsert"]; ok {
+				for k, v := range soi.(bson.M) {
+					baseOps["$setOnInsert"].(bson.M)[k] = v
+				}
+			}
+
+			for k, v := range ops {
+				if k == "$setOnInsert" {
+					continue
+				}
+				baseOps[k] = v
+			}
+		}
+
+		_, err = RunQuery(
+			mctx,
+			func() (interface{}, error) {
+				return c.Upsert(compiler.CompileFilter(mctx.Filter()), baseOps)
+			},
+			RetryInfo{
+				Operation:        elemental.OperationCreate,
+				Identity:         object.Identity(),
+				defaultRetryFunc: m.defaultRetryFunc,
+			},
+		)
+		object.SetIdentifier(id)
+	} else {
+		_, err = RunQuery(
+			mctx,
+			func() (interface{}, error) { return nil, c.Insert(object) },
+			RetryInfo{
+				Operation:        elemental.OperationCreate,
+				Identity:         object.Identity(),
+				defaultRetryFunc: m.defaultRetryFunc,
+			},
+		)
+	}
+
+	if err != nil {
 		sp.SetTag("error", true)
 		sp.LogFields(log.Error(err))
 		return err

--- a/manipmongo/options_test.go
+++ b/manipmongo/options_test.go
@@ -12,6 +12,7 @@
 package manipmongo
 
 import (
+	"context"
 	"crypto/tls"
 	"testing"
 	"time"
@@ -37,7 +38,7 @@ func (*fakeSharder) FilterMany(manipulate.TransactionalManipulator, manipulate.C
 	return nil, nil
 }
 
-func TestManipMongo_newConfig(t *testing.T) {
+func Test_newConfig(t *testing.T) {
 
 	Convey("Given call newConfig", t, func() {
 
@@ -56,7 +57,7 @@ func TestManipMongo_newConfig(t *testing.T) {
 	})
 }
 
-func TestManipMongo_Options(t *testing.T) {
+func Test_Options(t *testing.T) {
 
 	Convey("Calling OptionCredentials should work", t, func() {
 		c := newConfig()
@@ -136,5 +137,27 @@ func TestManipMongo_Options(t *testing.T) {
 		c := newConfig()
 		OptionExplain(m)(c)
 		So(c.explain, ShouldEqual, m)
+	})
+}
+
+func Test_ContextOptions(t *testing.T) {
+
+	Convey("Calling ContextOptionUpsert should work", t, func() {
+		b := bson.M{
+			"$setOnInsert": bson.M{"hello": "world"},
+		}
+		mctx := manipulate.NewContext(context.Background())
+		ContextOptionUpsert(b)(mctx)
+		So(mctx.(opaquer).Opaque()[opaqueKeyUpsert], ShouldEqual, b)
+	})
+
+	Convey("Calling ContextOptionUpsert with $set should panic", t, func() {
+		b := bson.M{"$set": true}
+		So(func() { ContextOptionUpsert(b)(nil) }, ShouldPanicWith, "cannot use $set in upsert operations")
+	})
+
+	Convey("Calling ContextOptionUpsert with $setOnInsert with _id should panic", t, func() {
+		b := bson.M{"$setOnInsert": bson.M{"_id": 1}}
+		So(func() { ContextOptionUpsert(b)(nil) }, ShouldPanicWith, "cannot use $setOnInsert on _id in upsert operations")
 	})
 }

--- a/options.go
+++ b/options.go
@@ -18,143 +18,143 @@ import (
 )
 
 // ContextOption represents an option can can be passed to NewContext.
-type ContextOption func(*mcontext)
+type ContextOption func(Context)
 
 // ContextOptionFilter sets the filter.
 func ContextOptionFilter(f *elemental.Filter) ContextOption {
-	return func(c *mcontext) {
-		c.filter = f
+	return func(c Context) {
+		c.(*mcontext).filter = f
 	}
 }
 
 // ContextOptionNamespace sets the namespace.
 func ContextOptionNamespace(n string) ContextOption {
-	return func(c *mcontext) {
-		c.namespace = n
+	return func(c Context) {
+		c.(*mcontext).namespace = n
 	}
 }
 
 // ContextOptionRecursive sets the recursive option of the context.
 func ContextOptionRecursive(r bool) ContextOption {
-	return func(c *mcontext) {
-		c.recursive = r
+	return func(c Context) {
+		c.(*mcontext).recursive = r
 	}
 }
 
 // ContextOptionVersion sets the version option of the context.
 func ContextOptionVersion(v int) ContextOption {
-	return func(c *mcontext) {
-		c.version = v
+	return func(c Context) {
+		c.(*mcontext).version = v
 	}
 }
 
 // ContextOptionOverride sets the override option of the context.
 func ContextOptionOverride(o bool) ContextOption {
-	return func(c *mcontext) {
-		c.overrideProtection = o
+	return func(c Context) {
+		c.(*mcontext).overrideProtection = o
 	}
 }
 
 // ContextOptionPage sets the pagination option of the context.
 func ContextOptionPage(n, size int) ContextOption {
-	return func(c *mcontext) {
-		c.page = n
-		c.pageSize = size
+	return func(c Context) {
+		c.(*mcontext).page = n
+		c.(*mcontext).pageSize = size
 	}
 }
 
 // ContextOptionAfter sets the lazy pagination option of the context.
 func ContextOptionAfter(from string, limit int) ContextOption {
-	return func(c *mcontext) {
-		c.after = from
-		c.limit = limit
+	return func(c Context) {
+		c.(*mcontext).after = from
+		c.(*mcontext).limit = limit
 	}
 }
 
 // ContextOptionTracking sets the opentracing tracking option of the context.
 func ContextOptionTracking(identifier, typ string) ContextOption {
-	return func(c *mcontext) {
-		c.externalTrackingID = identifier
-		c.externalTrackingType = typ
+	return func(c Context) {
+		c.(*mcontext).externalTrackingID = identifier
+		c.(*mcontext).externalTrackingType = typ
 	}
 }
 
 // ContextOptionOrder sets the ordering option of the context.
 func ContextOptionOrder(orders ...string) ContextOption {
-	return func(c *mcontext) {
-		c.order = orders
+	return func(c Context) {
+		c.(*mcontext).order = orders
 	}
 }
 
 // ContextOptionParameters sets the parameters option of the context.
 func ContextOptionParameters(p url.Values) ContextOption {
-	return func(c *mcontext) {
-		c.parameters = p
+	return func(c Context) {
+		c.(*mcontext).parameters = p
 	}
 }
 
 // ContextOptionFinalizer sets the create finalizer option of the context.
 func ContextOptionFinalizer(f FinalizerFunc) ContextOption {
-	return func(c *mcontext) {
-		c.createFinalizer = f
+	return func(c Context) {
+		c.(*mcontext).createFinalizer = f
 	}
 }
 
 // ContextOptionTransactionID sets the parameters option of the context.
 func ContextOptionTransactionID(tid TransactionID) ContextOption {
-	return func(c *mcontext) {
-		c.transactionID = tid
+	return func(c Context) {
+		c.(*mcontext).transactionID = tid
 	}
 }
 
 // ContextOptionParent sets the parent option of the context.
 func ContextOptionParent(i elemental.Identifiable) ContextOption {
-	return func(c *mcontext) {
-		c.parent = i
+	return func(c Context) {
+		c.(*mcontext).parent = i
 	}
 }
 
 // ContextOptionFields sets the list of fields to include in the reply.
 func ContextOptionFields(fields []string) ContextOption {
-	return func(c *mcontext) {
-		c.fields = fields
+	return func(c Context) {
+		c.(*mcontext).fields = fields
 	}
 }
 
 // ContextOptionWriteConsistency sets the desired write consistency of the request.
 func ContextOptionWriteConsistency(consistency WriteConsistency) ContextOption {
-	return func(c *mcontext) {
-		c.writeConsistency = consistency
+	return func(c Context) {
+		c.(*mcontext).writeConsistency = consistency
 	}
 }
 
 // ContextOptionReadConsistency sets the desired read consistency of the request.
 func ContextOptionReadConsistency(consistency ReadConsistency) ContextOption {
-	return func(c *mcontext) {
-		c.readConsistency = consistency
+	return func(c Context) {
+		c.(*mcontext).readConsistency = consistency
 	}
 }
 
 // ContextOptionCredentials sets user name and password for this context.
 func ContextOptionCredentials(username, password string) ContextOption {
-	return func(c *mcontext) {
-		c.username = username
-		c.password = password
+	return func(c Context) {
+		c.(*mcontext).username = username
+		c.(*mcontext).password = password
 	}
 }
 
 // ContextOptionToken sets the token for this request.
 func ContextOptionToken(token string) ContextOption {
-	return func(c *mcontext) {
-		c.username = "Bearer"
-		c.password = token
+	return func(c Context) {
+		c.(*mcontext).username = "Bearer"
+		c.(*mcontext).password = token
 	}
 }
 
 // ContextOptionClientIP sets the optional headers for the request.
 func ContextOptionClientIP(clientIP string) ContextOption {
-	return func(c *mcontext) {
-		c.clientIP = clientIP
+	return func(c Context) {
+		c.(*mcontext).clientIP = clientIP
 	}
 }
 
@@ -163,8 +163,8 @@ func ContextOptionClientIP(clientIP string) ContextOption {
 // the try number and the error. If it itself return an error, retrying will stop and
 // that error will be returned from the manipulator operation.
 func ContextOptionRetryFunc(f RetryFunc) ContextOption {
-	return func(c *mcontext) {
-		c.retryFunc = f
+	return func(c Context) {
+		c.(*mcontext).retryFunc = f
 	}
 }
 
@@ -179,14 +179,22 @@ func ContextOptionRetryFunc(f RetryFunc) ContextOption {
 // each retry will use a sub context with a timeout
 // of 30s.
 func ContextOptionRetryRatio(r int64) ContextOption {
-	return func(c *mcontext) {
-		c.retryRatio = r
+	return func(c Context) {
+		c.(*mcontext).retryRatio = r
 	}
 }
 
 // ContextOptionIdempotencyKey sets a custom idempotency key.
 func ContextOptionIdempotencyKey(key string) ContextOption {
-	return func(c *mcontext) {
-		c.idempotencyKey = key
+	return func(c Context) {
+		c.(*mcontext).idempotencyKey = key
+	}
+}
+
+// ContextOptionOpaque sets a opaque data. Their interpretation
+// depends on the manipulator implementation.
+func ContextOptionOpaque(o map[string]interface{}) ContextOption {
+	return func(c Context) {
+		c.(*mcontext).opaque = o
 	}
 }

--- a/options_test.go
+++ b/options_test.go
@@ -145,4 +145,10 @@ func TestManipulate_ContextOption(t *testing.T) {
 		ContextOptionIdempotencyKey("42")(mctx.(*mcontext))
 		So(mctx.(*mcontext).idempotencyKey, ShouldEqual, "42")
 	})
+
+	Convey("Calling ContextOptionOpaque should work", t, func() {
+		m := map[string]interface{}{}
+		ContextOptionOpaque(m)(mctx.(*mcontext))
+		So(mctx.(*mcontext).opaque, ShouldEqual, m)
+	})
 }


### PR DESCRIPTION
This patch allows manipulator implementations to enhance the context by providing additional options specific to that implementation.