### PR TITLE
new: added options to maniphttp manipulator and subscriber to pass credential as a cookie

### DIFF
--- a/internal/push/utils.go
+++ b/internal/push/utils.go
@@ -49,22 +49,25 @@ func decodeErrors(r io.Reader) error {
 func makeURL(u string, namespace string, password string, recursive bool) string {
 
 	u = strings.Replace(u, "https://", "wss://", 1)
-	u = fmt.Sprintf("%s?token=%s", u, password)
 
-	if namespace != "" {
-		u += "&namespace=" + url.QueryEscape(namespace)
+	args := []string{
+		fmt.Sprintf("namespace=%s", url.QueryEscape(namespace)),
+	}
+
+	if password != "" {
+		args = append(args, fmt.Sprintf("token=%s", password))
 	}
 
 	if recursive {
-		u = u + "&mode=all"
+		args = append(args, "mode=all")
 	}
 
-	return u
+	return fmt.Sprintf("%s?%s", u, strings.Join(args, "&"))
 }
 
 const maxBackoff = 8000
 
 func nextBackoff(try int) time.Duration {
 
-	return time.Duration(math.Min(math.Pow(2.0, float64(try))-1, maxBackoff)) * time.Millisecond
+	return time.Duration(math.Min(math.Pow(4.0, float64(try))-1, maxBackoff)) * time.Millisecond
 }

--- a/internal/push/utils_test.go
+++ b/internal/push/utils_test.go
@@ -1,0 +1,143 @@
+// Copyright 2019 Aporeto Inc.
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//     http://www.apache.org/licenses/LICENSE-2.0
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package push
+
+import (
+	"testing"
+	"time"
+)
+
+func Test_makeURL(t *testing.T) {
+	type args struct {
+		u         string
+		namespace string
+		password  string
+		recursive bool
+	}
+	tests := []struct {
+		name string
+		args args
+		want string
+	}{
+		{
+			"with password, recursive",
+			args{
+				"https://toto",
+				"/ns",
+				"password",
+				true,
+			},
+			"wss://toto?namespace=%2Fns&token=password&mode=all",
+		},
+		{
+			"with password, no recursive",
+			args{
+				"https://toto",
+				"/ns",
+				"password",
+				false,
+			},
+			"wss://toto?namespace=%2Fns&token=password",
+		},
+		{
+			"without password, recursive",
+			args{
+				"https://toto",
+				"/ns",
+				"",
+				true,
+			},
+			"wss://toto?namespace=%2Fns&mode=all",
+		},
+		{
+			"without password, no recursive",
+			args{
+				"https://toto",
+				"/ns",
+				"",
+				false,
+			},
+			"wss://toto?namespace=%2Fns",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := makeURL(tt.args.u, tt.args.namespace, tt.args.password, tt.args.recursive); got != tt.want {
+				t.Errorf("makeURL() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
+func Test_nextBackoff(t *testing.T) {
+	type args struct {
+		try int
+	}
+	tests := []struct {
+		name string
+		args args
+		want time.Duration
+	}{
+		{
+			"try 1",
+			args{0},
+			0,
+		},
+		{
+			"try 2",
+			args{1},
+			3 * time.Millisecond,
+		},
+		{
+			"try 3",
+			args{3},
+			63 * time.Millisecond,
+		},
+		{
+			"try 4",
+			args{4},
+			255 * time.Millisecond,
+		},
+		{
+			"try 5",
+			args{5},
+			1023 * time.Millisecond,
+		},
+		{
+			"try 6",
+			args{6},
+			4095 * time.Millisecond,
+		},
+		{
+			"try 7",
+			args{7},
+			8000 * time.Millisecond,
+		},
+		{
+			"try 8",
+			args{8},
+			8000 * time.Millisecond,
+		},
+		{
+			"try 1000",
+			args{1000},
+			8000 * time.Millisecond,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := nextBackoff(tt.args.try); got != tt.want {
+				t.Errorf("nextBackoff() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}

--- a/maniphttp/options.go
+++ b/maniphttp/options.go
@@ -125,9 +125,9 @@ func OptionDisableCompression() Option {
 	}
 }
 
-// OptionSendCrendientialAsCookie configures the manipulator to
+// OptionSendCrendentialsAsCookie configures the manipulator to
 // send the password as a cookie using the provided key.
-func OptionSendCrendientialAsCookie(key string) Option {
+func OptionSendCrendentialsAsCookie(key string) Option {
 	return func(m *httpManipulator) {
 		m.tokenCookieKey = key
 	}

--- a/maniphttp/options.go
+++ b/maniphttp/options.go
@@ -125,9 +125,9 @@ func OptionDisableCompression() Option {
 	}
 }
 
-// OptionSendCrendentialsAsCookie configures the manipulator to
+// OptionSendCredentialsAsCookie configures the manipulator to
 // send the password as a cookie using the provided key.
-func OptionSendCrendentialsAsCookie(key string) Option {
+func OptionSendCredentialsAsCookie(key string) Option {
 	return func(m *httpManipulator) {
 		m.tokenCookieKey = key
 	}

--- a/maniphttp/options.go
+++ b/maniphttp/options.go
@@ -125,6 +125,14 @@ func OptionDisableCompression() Option {
 	}
 }
 
+// OptionSendCrendientialAsCookie configures the manipulator to
+// send the password as a cookie using the provided key.
+func OptionSendCrendientialAsCookie(key string) Option {
+	return func(m *httpManipulator) {
+		m.tokenCookieKey = key
+	}
+}
+
 // OptionSimulateFailures will inject random error during
 // low level communication with the remote API.
 //

--- a/maniphttp/options_test.go
+++ b/maniphttp/options_test.go
@@ -115,4 +115,10 @@ func Test_Options(t *testing.T) {
 		OptionSimulateFailures(f)(m)
 		So(m.failureSimulations, ShouldEqual, f)
 	})
+
+	Convey("Calling OptionSendCrendientialAsCookie should work", t, func() {
+		m := &httpManipulator{}
+		OptionSendCrendientialAsCookie("x-token")(m)
+		So(m.tokenCookieKey, ShouldEqual, "x-token")
+	})
 }

--- a/maniphttp/options_test.go
+++ b/maniphttp/options_test.go
@@ -116,9 +116,9 @@ func Test_Options(t *testing.T) {
 		So(m.failureSimulations, ShouldEqual, f)
 	})
 
-	Convey("Calling OptionSendCrendientialAsCookie should work", t, func() {
+	Convey("Calling OptionSendCrendentialsAsCookie should work", t, func() {
 		m := &httpManipulator{}
-		OptionSendCrendientialAsCookie("x-token")(m)
+		OptionSendCrendentialsAsCookie("x-token")(m)
 		So(m.tokenCookieKey, ShouldEqual, "x-token")
 	})
 }

--- a/maniphttp/options_test.go
+++ b/maniphttp/options_test.go
@@ -116,9 +116,9 @@ func Test_Options(t *testing.T) {
 		So(m.failureSimulations, ShouldEqual, f)
 	})
 
-	Convey("Calling OptionSendCrendentialsAsCookie should work", t, func() {
+	Convey("Calling OptionSendCredentialsAsCookie should work", t, func() {
 		m := &httpManipulator{}
-		OptionSendCrendentialsAsCookie("x-token")(m)
+		OptionSendCredentialsAsCookie("x-token")(m)
 		So(m.tokenCookieKey, ShouldEqual, "x-token")
 	})
 }

--- a/maniphttp/subscriber.go
+++ b/maniphttp/subscriber.go
@@ -22,10 +22,11 @@ import (
 )
 
 type subscribeConfig struct {
-	namespace string
-	endpoint  string
-	recursive bool
-	tlsConfig *tls.Config
+	namespace           string
+	endpoint            string
+	recursive           bool
+	tlsConfig           *tls.Config
+	credentialCookieKey string
 }
 
 func newSubscribeConfig(m *httpManipulator) subscribeConfig {
@@ -64,6 +65,14 @@ func SubscriberOptionEndpoint(endpoint string) SubscriberOption {
 	}
 }
 
+// SubscriberSendCredentialsAsCookie makes the subscriber send the
+// crendentials as cookie using the provided key
+func SubscriberSendCredentialsAsCookie(key string) SubscriberOption {
+	return func(cfg *subscribeConfig) {
+		cfg.credentialCookieKey = key
+	}
+}
+
 // NewSubscriber returns a new subscription.
 func NewSubscriber(manipulator manipulate.Manipulator, options ...SubscriberOption) manipulate.Subscriber {
 
@@ -92,6 +101,7 @@ func NewSubscriber(manipulator manipulate.Manipulator, options ...SubscriberOpti
 			"Accept":       []string{string(m.encoding)},
 		},
 		cfg.recursive,
+		cfg.credentialCookieKey,
 	)
 }
 

--- a/maniphttp/subscriber_test.go
+++ b/maniphttp/subscriber_test.go
@@ -67,4 +67,10 @@ func TestOptions(t *testing.T) {
 		SubscriberOptionEndpoint("/labas/")(&cfg)
 		So(cfg.endpoint, ShouldEqual, "labas")
 	})
+
+	Convey("SubscriberSendCredentialsAsCookie should work", t, func() {
+		cfg := newSubscribeConfig(m)
+		SubscriberSendCredentialsAsCookie("creds")(&cfg)
+		So(cfg.credentialCookieKey, ShouldEqual, "creds")
+	})
 }


### PR DESCRIPTION
This patch provides the following changes:

- added option `maniphttp.OptionSendCredentialsAsCookie("key")` which will send the password in a cookie with the provided key instead of Authorization header when using http manipulator

- added option `maniphttp.SubscriberSendCredentialsAsCookie("key")` which will send the password in a cookie with the provided key instead of token parameter when connecting to the push channel

