### PR TITLE
new: add support for handling websocket error events

### DIFF
--- a/internal/push/push.go
+++ b/internal/push/push.go
@@ -40,6 +40,7 @@ type subscription struct {
 	errors                  chan error
 	events                  chan *elemental.Event
 	ns                      string
+	supportErrorEvents      bool
 	recursive               bool
 	status                  chan manipulate.SubscriberStatus
 	url                     string
@@ -64,6 +65,7 @@ func NewSubscriber(
 	unregisterTokenNotifier func(string),
 	tlsConfig *tls.Config,
 	headers http.Header,
+	supportErrorEvents bool,
 	recursive bool,
 	credsInTokenKey string,
 ) manipulate.Subscriber {
@@ -82,6 +84,7 @@ func NewSubscriber(
 		url:                     url,
 		ns:                      ns,
 		recursive:               recursive,
+		supportErrorEvents:      supportErrorEvents,
 		currentToken:            token,
 		currentTokenLock:        sync.RWMutex{},
 		unregisterTokenNotifier: unregisterTokenNotifier,
@@ -148,9 +151,9 @@ func (s *subscription) connect(ctx context.Context, initial bool) (err error) {
 		var url string
 		switch s.credsInTokenKey {
 		case "":
-			url = makeURL(s.url, s.ns, s.getCurrentToken(), s.recursive)
+			url = makeURL(s.url, s.ns, s.getCurrentToken(), s.recursive, s.supportErrorEvents)
 		default:
-			url = makeURL(s.url, s.ns, "", s.recursive)
+			url = makeURL(s.url, s.ns, "", s.recursive, s.supportErrorEvents)
 			s.config.Headers.Set("Cookie", fmt.Sprintf("%s=%s", s.credsInTokenKey, s.getCurrentToken()))
 		}
 

--- a/internal/push/utils.go
+++ b/internal/push/utils.go
@@ -63,7 +63,7 @@ func makeURL(u string, namespace string, password string, recursive, supportErro
 	}
 
 	if supportErrorEvents {
-		args = append(args, "supportsErrors=true")
+		args = append(args, "enableErrors=true")
 	}
 
 	return fmt.Sprintf("%s?%s", u, strings.Join(args, "&"))

--- a/internal/push/utils.go
+++ b/internal/push/utils.go
@@ -46,7 +46,7 @@ func decodeErrors(r io.Reader) error {
 	return errs
 }
 
-func makeURL(u string, namespace string, password string, recursive bool) string {
+func makeURL(u string, namespace string, password string, recursive, supportErrorEvents bool) string {
 
 	u = strings.Replace(u, "https://", "wss://", 1)
 
@@ -60,6 +60,10 @@ func makeURL(u string, namespace string, password string, recursive bool) string
 
 	if recursive {
 		args = append(args, "mode=all")
+	}
+
+	if supportErrorEvents {
+		args = append(args, "supportsErrors=true")
 	}
 
 	return fmt.Sprintf("%s?%s", u, strings.Join(args, "&"))

--- a/internal/push/utils_test.go
+++ b/internal/push/utils_test.go
@@ -82,7 +82,7 @@ func Test_makeURL(t *testing.T) {
 				false,
 				true,
 			},
-			"wss://toto?namespace=%2Fns&supportsErrors=true",
+			"wss://toto?namespace=%2Fns&enableErrors=true",
 		},
 	}
 	for _, tt := range tests {

--- a/internal/push/utils_test.go
+++ b/internal/push/utils_test.go
@@ -18,10 +18,11 @@ import (
 
 func Test_makeURL(t *testing.T) {
 	type args struct {
-		u         string
-		namespace string
-		password  string
-		recursive bool
+		u             string
+		namespace     string
+		password      string
+		recursive     bool
+		supportErrors bool
 	}
 	tests := []struct {
 		name string
@@ -35,6 +36,7 @@ func Test_makeURL(t *testing.T) {
 				"/ns",
 				"password",
 				true,
+				false,
 			},
 			"wss://toto?namespace=%2Fns&token=password&mode=all",
 		},
@@ -44,6 +46,7 @@ func Test_makeURL(t *testing.T) {
 				"https://toto",
 				"/ns",
 				"password",
+				false,
 				false,
 			},
 			"wss://toto?namespace=%2Fns&token=password",
@@ -55,6 +58,7 @@ func Test_makeURL(t *testing.T) {
 				"/ns",
 				"",
 				true,
+				false,
 			},
 			"wss://toto?namespace=%2Fns&mode=all",
 		},
@@ -65,13 +69,25 @@ func Test_makeURL(t *testing.T) {
 				"/ns",
 				"",
 				false,
+				false,
 			},
 			"wss://toto?namespace=%2Fns",
+		},
+		{
+			"with support errors",
+			args{
+				"https://toto",
+				"/ns",
+				"",
+				false,
+				true,
+			},
+			"wss://toto?namespace=%2Fns&supportsErrors=true",
 		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			if got := makeURL(tt.args.u, tt.args.namespace, tt.args.password, tt.args.recursive); got != tt.want {
+			if got := makeURL(tt.args.u, tt.args.namespace, tt.args.password, tt.args.recursive, tt.args.supportErrors); got != tt.want {
 				t.Errorf("makeURL() = %v, want %v", got, tt.want)
 			}
 		})

--- a/maniphttp/manipulator_test.go
+++ b/maniphttp/manipulator_test.go
@@ -1312,7 +1312,7 @@ func TestHTTP_send(t *testing.T) {
 		}))
 		defer ts.Close()
 
-		ctx, cancel := context.WithTimeout(context.Background(), 1*time.Second)
+		ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
 		defer cancel()
 
 		resp, err := m.(*httpManipulator).send(manipulate.NewContext(ctx), http.MethodPost, ts.URL, nil, nil, sp)
@@ -1337,7 +1337,7 @@ func TestHTTP_send(t *testing.T) {
 		}))
 		defer ts.Close()
 
-		ctx, cancel := context.WithTimeout(context.Background(), 1*time.Second)
+		ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
 		defer cancel()
 
 		resp, err := m.(*httpManipulator).send(manipulate.NewContext(ctx), http.MethodPost, ts.URL, nil, nil, sp)
@@ -1362,7 +1362,7 @@ func TestHTTP_send(t *testing.T) {
 		}))
 		defer ts.Close()
 
-		ctx, cancel := context.WithTimeout(context.Background(), 1*time.Second)
+		ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
 		defer cancel()
 
 		resp, err := m.(*httpManipulator).send(manipulate.NewContext(ctx), http.MethodPost, ts.URL, nil, nil, sp)

--- a/maniphttp/manipulator_test.go
+++ b/maniphttp/manipulator_test.go
@@ -1040,7 +1040,7 @@ func TestHTTP_send(t *testing.T) {
 		}))
 		defer ts.Close()
 
-		ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+		ctx, cancel := context.WithTimeout(context.Background(), 1*time.Second)
 		defer cancel()
 
 		resp, err := m.(*httpManipulator).send(manipulate.NewContext(ctx), http.MethodPost, ts.URL, nil, nil, sp)
@@ -1065,7 +1065,7 @@ func TestHTTP_send(t *testing.T) {
 
 		Convey("When I call send", func() {
 
-			ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+			ctx, cancel := context.WithTimeout(context.Background(), 1*time.Second)
 			defer cancel()
 
 			resp, err := m.(*httpManipulator).send(manipulate.NewContext(ctx), http.MethodPost, ts.URL, nil, nil, sp)
@@ -1091,7 +1091,7 @@ func TestHTTP_send(t *testing.T) {
 		}))
 		defer ts.Close()
 
-		ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+		ctx, cancel := context.WithTimeout(context.Background(), 1*time.Second)
 		defer cancel()
 
 		var t int
@@ -1134,7 +1134,7 @@ func TestHTTP_send(t *testing.T) {
 		}))
 		defer ts.Close()
 
-		ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+		ctx, cancel := context.WithTimeout(context.Background(), 1*time.Second)
 		defer cancel()
 
 		var t int
@@ -1186,7 +1186,7 @@ func TestHTTP_send(t *testing.T) {
 		}))
 		defer ts.Close()
 
-		ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+		ctx, cancel := context.WithTimeout(context.Background(), 1*time.Second)
 		defer cancel()
 
 		resp, err := m.(*httpManipulator).send(
@@ -1231,7 +1231,7 @@ func TestHTTP_send(t *testing.T) {
 		}))
 		defer ts.Close()
 
-		ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+		ctx, cancel := context.WithTimeout(context.Background(), 1*time.Second)
 		defer cancel()
 
 		resp, err := m.(*httpManipulator).send(
@@ -1287,7 +1287,7 @@ func TestHTTP_send(t *testing.T) {
 		}))
 		defer ts.Close()
 
-		ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+		ctx, cancel := context.WithTimeout(context.Background(), 1*time.Second)
 		defer cancel()
 
 		resp, err := m.(*httpManipulator).send(manipulate.NewContext(ctx), http.MethodPost, ts.URL, nil, nil, sp)
@@ -1312,7 +1312,7 @@ func TestHTTP_send(t *testing.T) {
 		}))
 		defer ts.Close()
 
-		ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+		ctx, cancel := context.WithTimeout(context.Background(), 1*time.Second)
 		defer cancel()
 
 		resp, err := m.(*httpManipulator).send(manipulate.NewContext(ctx), http.MethodPost, ts.URL, nil, nil, sp)
@@ -1337,7 +1337,7 @@ func TestHTTP_send(t *testing.T) {
 		}))
 		defer ts.Close()
 
-		ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+		ctx, cancel := context.WithTimeout(context.Background(), 1*time.Second)
 		defer cancel()
 
 		resp, err := m.(*httpManipulator).send(manipulate.NewContext(ctx), http.MethodPost, ts.URL, nil, nil, sp)
@@ -1362,7 +1362,7 @@ func TestHTTP_send(t *testing.T) {
 		}))
 		defer ts.Close()
 
-		ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+		ctx, cancel := context.WithTimeout(context.Background(), 1*time.Second)
 		defer cancel()
 
 		resp, err := m.(*httpManipulator).send(manipulate.NewContext(ctx), http.MethodPost, ts.URL, nil, nil, sp)
@@ -1387,7 +1387,7 @@ func TestHTTP_send(t *testing.T) {
 		}))
 		defer ts.Close()
 
-		ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+		ctx, cancel := context.WithTimeout(context.Background(), 1*time.Second)
 		defer cancel()
 
 		resp, err := m.(*httpManipulator).send(manipulate.NewContext(ctx), http.MethodPost, ts.URL, nil, nil, sp)
@@ -1567,7 +1567,7 @@ func TestHTTP_send(t *testing.T) {
 		}))
 		defer ts.Close()
 
-		ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+		ctx, cancel := context.WithTimeout(context.Background(), 1*time.Second)
 		defer cancel()
 
 		resp, err := m.(*httpManipulator).send(manipulate.NewContext(ctx), http.MethodPost, ts.URL, nil, nil, sp)

--- a/maniphttp/manipulator_test.go
+++ b/maniphttp/manipulator_test.go
@@ -1040,7 +1040,7 @@ func TestHTTP_send(t *testing.T) {
 		}))
 		defer ts.Close()
 
-		ctx, cancel := context.WithTimeout(context.Background(), 1*time.Second)
+		ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
 		defer cancel()
 
 		resp, err := m.(*httpManipulator).send(manipulate.NewContext(ctx), http.MethodPost, ts.URL, nil, nil, sp)
@@ -1065,7 +1065,7 @@ func TestHTTP_send(t *testing.T) {
 
 		Convey("When I call send", func() {
 
-			ctx, cancel := context.WithTimeout(context.Background(), 1*time.Second)
+			ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
 			defer cancel()
 
 			resp, err := m.(*httpManipulator).send(manipulate.NewContext(ctx), http.MethodPost, ts.URL, nil, nil, sp)
@@ -1091,7 +1091,7 @@ func TestHTTP_send(t *testing.T) {
 		}))
 		defer ts.Close()
 
-		ctx, cancel := context.WithTimeout(context.Background(), 1*time.Second)
+		ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
 		defer cancel()
 
 		var t int
@@ -1134,7 +1134,7 @@ func TestHTTP_send(t *testing.T) {
 		}))
 		defer ts.Close()
 
-		ctx, cancel := context.WithTimeout(context.Background(), 1*time.Second)
+		ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
 		defer cancel()
 
 		var t int
@@ -1186,7 +1186,7 @@ func TestHTTP_send(t *testing.T) {
 		}))
 		defer ts.Close()
 
-		ctx, cancel := context.WithTimeout(context.Background(), 1*time.Second)
+		ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
 		defer cancel()
 
 		resp, err := m.(*httpManipulator).send(
@@ -1231,7 +1231,7 @@ func TestHTTP_send(t *testing.T) {
 		}))
 		defer ts.Close()
 
-		ctx, cancel := context.WithTimeout(context.Background(), 1*time.Second)
+		ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
 		defer cancel()
 
 		resp, err := m.(*httpManipulator).send(
@@ -1287,7 +1287,7 @@ func TestHTTP_send(t *testing.T) {
 		}))
 		defer ts.Close()
 
-		ctx, cancel := context.WithTimeout(context.Background(), 1*time.Second)
+		ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
 		defer cancel()
 
 		resp, err := m.(*httpManipulator).send(manipulate.NewContext(ctx), http.MethodPost, ts.URL, nil, nil, sp)

--- a/maniphttp/manipulator_test.go
+++ b/maniphttp/manipulator_test.go
@@ -1387,7 +1387,7 @@ func TestHTTP_send(t *testing.T) {
 		}))
 		defer ts.Close()
 
-		ctx, cancel := context.WithTimeout(context.Background(), 1*time.Second)
+		ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
 		defer cancel()
 
 		resp, err := m.(*httpManipulator).send(manipulate.NewContext(ctx), http.MethodPost, ts.URL, nil, nil, sp)
@@ -1567,7 +1567,7 @@ func TestHTTP_send(t *testing.T) {
 		}))
 		defer ts.Close()
 
-		ctx, cancel := context.WithTimeout(context.Background(), 1*time.Second)
+		ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
 		defer cancel()
 
 		resp, err := m.(*httpManipulator).send(manipulate.NewContext(ctx), http.MethodPost, ts.URL, nil, nil, sp)

--- a/maniphttp/subscriber.go
+++ b/maniphttp/subscriber.go
@@ -23,10 +23,11 @@ import (
 
 type subscribeConfig struct {
 	namespace           string
+	credentialCookieKey string
 	endpoint            string
+	supportErrorEvents  bool
 	recursive           bool
 	tlsConfig           *tls.Config
-	credentialCookieKey string
 }
 
 func newSubscribeConfig(m *httpManipulator) subscribeConfig {
@@ -73,6 +74,14 @@ func SubscriberSendCredentialsAsCookie(key string) SubscriberOption {
 	}
 }
 
+// SubscriberOptionSupportErrorEvents will result in connecting to the socket server by declaring that you are capable of
+// handling error events.
+func SubscriberOptionSupportErrorEvents() SubscriberOption {
+	return func(cfg *subscribeConfig) {
+		cfg.supportErrorEvents = true
+	}
+}
+
 // NewSubscriber returns a new subscription.
 func NewSubscriber(manipulator manipulate.Manipulator, options ...SubscriberOption) manipulate.Subscriber {
 
@@ -100,6 +109,7 @@ func NewSubscriber(manipulator manipulate.Manipulator, options ...SubscriberOpti
 			"Content-Type": []string{string(m.encoding)},
 			"Accept":       []string{string(m.encoding)},
 		},
+		cfg.supportErrorEvents,
 		cfg.recursive,
 		cfg.credentialCookieKey,
 	)

--- a/maniphttp/subscriber_test.go
+++ b/maniphttp/subscriber_test.go
@@ -37,8 +37,8 @@ func TestNewSubscriberOption(t *testing.T) {
 				So(cfg.endpoint, ShouldEqual, "events")
 				So(cfg.namespace, ShouldEqual, "mns")
 				So(cfg.tlsConfig, ShouldEqual, m.tlsConfig)
+				So(cfg.supportErrorEvents, ShouldBeFalse)
 			})
-
 		})
 	})
 }
@@ -72,5 +72,11 @@ func TestOptions(t *testing.T) {
 		cfg := newSubscribeConfig(m)
 		SubscriberSendCredentialsAsCookie("creds")(&cfg)
 		So(cfg.credentialCookieKey, ShouldEqual, "creds")
+	})
+
+	Convey("SubscriberOptionSupportErrorEvents should work", t, func() {
+		cfg := newSubscribeConfig(m)
+		SubscriberOptionSupportErrorEvents()(&cfg)
+		So(cfg.supportErrorEvents, ShouldBeTrue)
 	})
 }


### PR DESCRIPTION
addresses: https://github.com/aporeto-inc/aporeto/issues/2500

### ASK ❓

- Should we add new event types to indicate that the client is now in an error state and/or leaving an error state?

### TODO

✅ Unit tests