### PR TITLE
Fixes on Manipulate http and backoff

### DIFF
--- a/internal/backoff/backoff.go
+++ b/internal/backoff/backoff.go
@@ -18,7 +18,7 @@ func Next(try int, deadline time.Time) time.Duration {
 	}
 
 	now := time.Now().Round(time.Second)
-	if now.Add(wait).After(deadline) {
+	if now.Add(wait).After(deadline) && deadline.Sub(now) > 0 {
 		return deadline.Sub(now)
 	}
 

--- a/internal/backoff/backoff_test.go
+++ b/internal/backoff/backoff_test.go
@@ -160,6 +160,14 @@ func TestNext(t *testing.T) {
 			},
 			1 * time.Second,
 		},
+		{
+			"almost expired deadline with, try 1",
+			args{
+				1,
+				time.Now().Add(1000 * time.Nanosecond),
+			},
+			1 * time.Millisecond,
+		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {

--- a/maniphttp/manipulator.go
+++ b/maniphttp/manipulator.go
@@ -755,7 +755,13 @@ func (s *httpManipulator) send(
 
 		// If we have content, we return the response.
 		// The body will be drained by the defered call to closeCurrentBody().
-		if response.StatusCode == http.StatusNoContent || response.ContentLength == 0 || dest == nil {
+		if response.StatusCode == http.StatusNoContent || response.ContentLength == 0 {
+			bodyCloser = nil
+
+			return response, nil
+		}
+
+		if dest == nil {
 			return response, nil
 		}
 

--- a/maniphttp/manipulator.go
+++ b/maniphttp/manipulator.go
@@ -688,7 +688,7 @@ func (s *httpManipulator) send(
 
 		// We passed the basic error, we have a body.
 		// We register it so next loop will be clean.
-		bodyCloser = request.Body
+		bodyCloser = response.Body
 
 		// We check for http status codes that triggers a retry
 		switch response.StatusCode {
@@ -755,13 +755,7 @@ func (s *httpManipulator) send(
 
 		// If we have content, we return the response.
 		// The body will be drained by the defered call to closeCurrentBody().
-		if response.StatusCode == http.StatusNoContent || response.ContentLength == 0 {
-			bodyCloser = nil
-
-			return response, nil
-		}
-
-		if dest == nil {
+		if response.StatusCode == http.StatusNoContent || response.ContentLength == 0 || dest == nil {
 			return response, nil
 		}
 
@@ -779,8 +773,8 @@ func (s *httpManipulator) send(
 		//
 
 		// We cancel any pending request context and the pending body.
-		cancelCurrentRequest()
 		closeCurrentBody()
+		cancelCurrentRequest()
 
 		// If the manipulator has auto retry disabled we return the last error
 		if s.disableAutoRetry {


### PR DESCRIPTION
This PR fix the following:
- in the backoff Next, if the deadline is expired, do not return a negative wait duration
- in manipulate http, correctly close the response body so keep alive is used (Avoid to do new TLS handshake in case of retries)