### PR TITLE
fix: do not overwrite last error if it was previously set - fixes flaky tests

### DIFF
--- a/maniphttp/manipulator.go
+++ b/maniphttp/manipulator.go
@@ -667,7 +667,9 @@ func (s *httpManipulator) send(
 				goto RETRY
 
 			case io.ErrUnexpectedEOF, io.EOF:
-				lastError = manipulate.NewErrCannotCommunicate(snip.Snip(err, s.currentPassword()).Error())
+				if lastError == nil {
+					lastError = manipulate.NewErrCannotCommunicate(snip.Snip(err, s.currentPassword()).Error())
+				}
 				goto RETRY
 			}
 
@@ -675,7 +677,9 @@ func (s *httpManipulator) send(
 			switch uerr.Err.(type) {
 
 			case net.Error:
-				lastError = manipulate.NewErrCannotCommunicate(snip.Snip(err, s.currentPassword()).Error())
+				if lastError == nil {
+					lastError = manipulate.NewErrCannotCommunicate(snip.Snip(err, s.currentPassword()).Error())
+				}
 				goto RETRY
 
 			case x509.UnknownAuthorityError, x509.CertificateInvalidError, x509.HostnameError:


### PR DESCRIPTION
I believe the root cause of the flakiness is because the last status from the server is being overwritten in the event of a retry that resulted in the request context exceeding its deadline (_or a network error_). See:

• https://github.com/aporeto-inc/manipulate/blob/master/maniphttp/manipulator.go#L670
• https://github.com/aporeto-inc/manipulate/blob/master/maniphttp/manipulator.go#L678

Instead, what I believe it should do is only assign the `NewErrCannotCommunicate` to `lastError` IFF `lastError != nil` because there could have been a connection to the server which failed due to any of the following HTTP status codes: https://github.com/aporeto-inc/manipulate/blob/master/maniphttp/manipulator.go#L696-L719

The tests are failing because the last status is sometimes thrown away if there was a network connectivity error or the request context deadline exceeds (during a retry attempt to the test server).


For example, we have a test that brings up a server that returns 429 and we assert that we get back a `manipulate.ErrTooManyRequests` error. However, this test sometimes fails because a retry results in a `manipulate.NewErrCannotCommunicate` error.

This is happening because the last status from the server was thrown away in the two snippets I posted above :top:

Flow:

- Hit server, got back 429 (ok I will retry)
- Hit server, got back 429 (ok I will retry)
- Hit server, get back 429 (ok I will retry)
- Hit server, get back 429 (ok I will retry)
- (_last retry attempt_) *This guy now fails randomly due to a network error or the sub-context deadline exceeding - the `lastError` is now overwritten w/ `manipulate.NewErrCannotCommunicate`*

_Now the function returns with a `manipulate.NewErrCannotCommunicate` error instead of a `manipulate.ErrTooManyRequests` error even though we reached the server in some of the retry attempts_