### PR TITLE
fixed: use bson.D for filters instead of bson.M

### DIFF
--- a/manipmongo/helpers.go
+++ b/manipmongo/helpers.go
@@ -26,7 +26,7 @@ import (
 )
 
 // CompileFilter compiles the given manipulate filter into a raw mongo filter.
-func CompileFilter(f *elemental.Filter) bson.M {
+func CompileFilter(f *elemental.Filter) bson.D {
 	return compiler.CompileFilter(f)
 }
 

--- a/manipmongo/helpers_test.go
+++ b/manipmongo/helpers_test.go
@@ -36,8 +36,27 @@ func TestCompileFilter(t *testing.T) {
 
 			cf := CompileFilter(f)
 
+			ddd := bson.D{
+				{
+					Name: "$and",
+					Value: []bson.D{
+						{
+							{
+								Name: "a",
+								Value: bson.D{
+									{
+										Name:  "$eq",
+										Value: "b",
+									},
+								},
+							},
+						},
+					},
+				},
+			}
+
 			Convey("Then cf should be correct", func() {
-				So(cf, ShouldResemble, bson.M{"$and": []bson.M{{"a": bson.M{"$eq": "b"}}}})
+				So(cf, ShouldResemble, ddd)
 			})
 		})
 	})

--- a/manipmongo/internal/compiler/filter_test.go
+++ b/manipmongo/internal/compiler/filter_test.go
@@ -14,6 +14,7 @@ package compiler
 import (
 	"strings"
 	"testing"
+	"time"
 
 	"github.com/globalsign/mgo/bson"
 	. "github.com/smartystreets/goconvey/convey"
@@ -193,6 +194,21 @@ func TestUtils_compiler(t *testing.T) {
 
 			Convey("Then the bson should be correct", func() {
 				So(strings.Replace(string(b), "\n", "", 1), ShouldEqual, `{"$and":[{"x":{"$exists":true}}]}`)
+			})
+		})
+	})
+
+	Convey("Given I have filter that contains a duration", t, func() {
+
+		f := elemental.NewFilterComposer().
+			WithKey("x").Equals(3 * time.Second).
+			Done()
+
+		Convey("When I compile the filter", func() {
+			b, _ := bson.MarshalJSON(toMap(CompileFilter(f)))
+
+			Convey("Then the bson should be correct", func() {
+				So(strings.Replace(string(b), "\n", "", 1), ShouldStartWith, `{"$and":[{"x":{"$eq":{"$date":"`)
 			})
 		})
 	})

--- a/manipmongo/internal/compiler/filter_test.go
+++ b/manipmongo/internal/compiler/filter_test.go
@@ -20,6 +20,32 @@ import (
 	"go.aporeto.io/elemental"
 )
 
+func toMap(in bson.D) bson.M {
+
+	out := make(bson.M, len(in))
+
+	for _, item := range in {
+
+		switch iv := item.Value.(type) {
+
+		case bson.D:
+			out[item.Name] = toMap(iv)
+
+		case []bson.D:
+			outs := make([]bson.M, len(iv))
+			for i, subitem := range iv {
+				outs[i] = toMap(subitem)
+			}
+			out[item.Name] = outs
+
+		default:
+			out[item.Name] = item.Value
+		}
+	}
+
+	return out
+}
+
 func TestUtils_compiler(t *testing.T) {
 
 	Convey("Given I have a empty manipulate.Filter", t, func() {
@@ -28,7 +54,7 @@ func TestUtils_compiler(t *testing.T) {
 
 		Convey("When I compile the filter", func() {
 
-			b, _ := bson.MarshalJSON(CompileFilter(f))
+			b, _ := bson.MarshalJSON(toMap(CompileFilter(f)))
 
 			Convey("Then the bson should be correct", func() {
 				So(strings.Replace(string(b), "\n", "", 1), ShouldEqual, `{}`)
@@ -42,7 +68,7 @@ func TestUtils_compiler(t *testing.T) {
 
 		Convey("When I compile the filter", func() {
 
-			b, _ := bson.MarshalJSON(CompileFilter(f))
+			b, _ := bson.MarshalJSON(toMap(CompileFilter(f)))
 
 			Convey("Then the bson should be correct", func() {
 				So(strings.Replace(string(b), "\n", "", 1), ShouldEqual, `{"$and":[{"_id":{"$eq":{"$oid":"5d83e7eedb40280001887565"}}}]}`)
@@ -56,7 +82,7 @@ func TestUtils_compiler(t *testing.T) {
 
 		Convey("When I compile the filter", func() {
 
-			b, _ := bson.MarshalJSON(CompileFilter(f))
+			b, _ := bson.MarshalJSON(toMap(CompileFilter(f)))
 
 			Convey("Then the bson should be correct", func() {
 				So(strings.Replace(string(b), "\n", "", 1), ShouldEqual, `{"$and":[{"bool":{"$eq":true}}]}`)
@@ -70,7 +96,7 @@ func TestUtils_compiler(t *testing.T) {
 
 		Convey("When I compile the filter", func() {
 
-			b, _ := bson.MarshalJSON(CompileFilter(f))
+			b, _ := bson.MarshalJSON(toMap(CompileFilter(f)))
 
 			Convey("Then the bson should be correct", func() {
 				So(strings.Replace(string(b), "\n", "", 1), ShouldEqual, `{"$and":[{"$or":[{"bool":{"$eq":false}},{"bool":{"$exists":false}}]}]}`)
@@ -84,7 +110,7 @@ func TestUtils_compiler(t *testing.T) {
 
 		Convey("When I compile the filter", func() {
 
-			b, _ := bson.MarshalJSON(CompileFilter(f))
+			b, _ := bson.MarshalJSON(toMap(CompileFilter(f)))
 
 			Convey("Then the bson should be correct", func() {
 				So(strings.Replace(string(b), "\n", "", 1), ShouldEqual, `{"$and":[{"x.TOTO.Titu":{"$eq":1}}]}`)
@@ -98,7 +124,7 @@ func TestUtils_compiler(t *testing.T) {
 
 		Convey("When I compile the filter", func() {
 
-			b, _ := bson.MarshalJSON(CompileFilter(f))
+			b, _ := bson.MarshalJSON(toMap(CompileFilter(f)))
 
 			Convey("Then the bson should be correct", func() {
 				So(strings.Replace(string(b), "\n", "", 1), ShouldEqual, `{"$and":[{"x":{"$eq":1}},{"y":{"$eq":2}}]}`)
@@ -112,7 +138,7 @@ func TestUtils_compiler(t *testing.T) {
 
 		Convey("When I compile the filter", func() {
 
-			b, _ := bson.MarshalJSON(CompileFilter(f))
+			b, _ := bson.MarshalJSON(toMap(CompileFilter(f)))
 
 			Convey("Then the bson should be correct", func() {
 				So(strings.Replace(string(b), "\n", "", 1), ShouldEqual, `{"$and":[{"x":{"$ne":1}},{"x":{"$ne":2}}]}`)
@@ -133,7 +159,7 @@ func TestUtils_compiler(t *testing.T) {
 
 		Convey("When I compile the filter", func() {
 
-			b, _ := bson.MarshalJSON(CompileFilter(f))
+			b, _ := bson.MarshalJSON(toMap(CompileFilter(f)))
 
 			Convey("Then the bson should be correct", func() {
 				So(strings.Replace(string(b), "\n", "", 1), ShouldEqual, `{"$and":[{"x":{"$eq":1}},{"z":{"$in":["a","b"]}},{"a":{"$gte":1}},{"b":{"$lte":1}},{"c":{"$gt":1}},{"d":{"$lt":1}}]}`)
@@ -148,7 +174,7 @@ func TestUtils_compiler(t *testing.T) {
 			Done()
 
 		Convey("When I compile the filter", func() {
-			b, _ := bson.MarshalJSON(CompileFilter(f))
+			b, _ := bson.MarshalJSON(toMap(CompileFilter(f)))
 
 			Convey("Then the bson should be correct", func() {
 				So(strings.Replace(string(b), "\n", "", 1), ShouldEqual, `{"$and":[{"$or":[{"x":{"$regex":"$abc^"}},{"x":{"$regex":".*"}}]}]}`)
@@ -163,7 +189,7 @@ func TestUtils_compiler(t *testing.T) {
 			Done()
 
 		Convey("When I compile the filter", func() {
-			b, _ := bson.MarshalJSON(CompileFilter(f))
+			b, _ := bson.MarshalJSON(toMap(CompileFilter(f)))
 
 			Convey("Then the bson should be correct", func() {
 				So(strings.Replace(string(b), "\n", "", 1), ShouldEqual, `{"$and":[{"x":{"$exists":true}}]}`)
@@ -178,7 +204,7 @@ func TestUtils_compiler(t *testing.T) {
 			Done()
 
 		Convey("When I compile the filter", func() {
-			b, _ := bson.MarshalJSON(CompileFilter(f))
+			b, _ := bson.MarshalJSON(toMap(CompileFilter(f)))
 
 			Convey("Then the bson should be correct", func() {
 				So(strings.Replace(string(b), "\n", "", 1), ShouldEqual, `{"$and":[{"x":{"$exists":false}}]}`)
@@ -193,7 +219,7 @@ func TestUtils_compiler(t *testing.T) {
 			Done()
 
 		Convey("When I compile the filter", func() {
-			b, _ := bson.MarshalJSON(CompileFilter(f))
+			b, _ := bson.MarshalJSON(toMap(CompileFilter(f)))
 
 			Convey("Then the bson should be correct", func() {
 				So(strings.Replace(string(b), "\n", "", 1), ShouldEqual, `{"$and":[{"_id":{"$eq":{"$oid":"5d85727b919e0c397a58e940"}}}]}`)
@@ -208,7 +234,7 @@ func TestUtils_compiler(t *testing.T) {
 			Done()
 
 		Convey("When I compile the filter", func() {
-			b, _ := bson.MarshalJSON(CompileFilter(f))
+			b, _ := bson.MarshalJSON(toMap(CompileFilter(f)))
 
 			Convey("Then the bson should be correct", func() {
 				So(strings.Replace(string(b), "\n", "", 1), ShouldEqual, `{"$and":[{"_id":{"$eq":"not-object-id"}}]}`)
@@ -223,7 +249,7 @@ func TestUtils_compiler(t *testing.T) {
 			Done()
 
 		Convey("When I compile the filter", func() {
-			b, _ := bson.MarshalJSON(CompileFilter(f))
+			b, _ := bson.MarshalJSON(toMap(CompileFilter(f)))
 
 			Convey("Then the bson should be correct", func() {
 				So(strings.Replace(string(b), "\n", "", 1), ShouldEqual, `{"$and":[{"_id":{"$eq":{"$oid":"5d85727b919e0c397a58e940"}}}]}`)
@@ -238,7 +264,7 @@ func TestUtils_compiler(t *testing.T) {
 			Done()
 
 		Convey("When I compile the filter", func() {
-			b, _ := bson.MarshalJSON(CompileFilter(f))
+			b, _ := bson.MarshalJSON(toMap(CompileFilter(f)))
 
 			Convey("Then the bson should be correct", func() {
 				So(strings.Replace(string(b), "\n", "", 1), ShouldEqual, `{"$and":[{"_id":{"$eq":{"$oid":"5d85727b919e0c397a58e940"}}}]}`)
@@ -253,7 +279,7 @@ func TestUtils_compiler(t *testing.T) {
 			Done()
 
 		Convey("When I compile the filter", func() {
-			b, _ := bson.MarshalJSON(CompileFilter(f))
+			b, _ := bson.MarshalJSON(toMap(CompileFilter(f)))
 
 			Convey("Then the bson should be correct", func() {
 				So(strings.Replace(string(b), "\n", "", 1), ShouldEqual, `{"$and":[{"_id":{"$in":[{"$oid":"5d85727b919e0c397a58e940"},{"$oid":"5d85727b919e0c397a58e941"}]}}]}`)
@@ -268,7 +294,7 @@ func TestUtils_compiler(t *testing.T) {
 			Done()
 
 		Convey("When I compile the filter", func() {
-			b, _ := bson.MarshalJSON(CompileFilter(f))
+			b, _ := bson.MarshalJSON(toMap(CompileFilter(f)))
 
 			Convey("Then the bson should be correct", func() {
 				So(strings.Replace(string(b), "\n", "", 1), ShouldEqual, `{"$and":[{"_id":{"$in":["not-object-id",{"$oid":"5d85727b919e0c397a58e941"}]}}]}`)
@@ -283,7 +309,7 @@ func TestUtils_compiler(t *testing.T) {
 			Done()
 
 		Convey("When I compile the filter", func() {
-			b, _ := bson.MarshalJSON(CompileFilter(f))
+			b, _ := bson.MarshalJSON(toMap(CompileFilter(f)))
 
 			Convey("Then the bson should be correct", func() {
 				So(strings.Replace(string(b), "\n", "", 1), ShouldEqual, `{"$and":[{"_id":{"$nin":[{"$oid":"5d85727b919e0c397a58e940"},{"$oid":"5d85727b919e0c397a58e941"}]}}]}`)
@@ -318,7 +344,7 @@ func TestUtils_compiler(t *testing.T) {
 			Done()
 
 		Convey("When I compile the filter", func() {
-			b, _ := bson.MarshalJSON(CompileFilter(f))
+			b, _ := bson.MarshalJSON(toMap(CompileFilter(f)))
 
 			Convey("Then the bson should be correct", func() {
 				So(strings.Replace(string(b), "\n", "", 1), ShouldEqual, `{"$and":[{"namespace":{"$eq":"coucou"}},{"$and":[{"$and":[{"name":{"$eq":"toto"}},{"surname":{"$eq":"titi"}}]},{"$and":[{"color":{"$eq":"blue"}},{"$or":[{"$and":[{"size":{"$eq":"big"}}]},{"$and":[{"size":{"$eq":"medium"}}]},{"$and":[{"list":{"$nin":["a","b","c"]}}]}]}]}]}]}`)

--- a/manipmongo/manipulator.go
+++ b/manipmongo/manipulator.go
@@ -269,22 +269,12 @@ func (m *mongoManipulator) Retrieve(mctx manipulate.Context, object elemental.Id
 			return manipulate.NewErrCannotBuildQuery(fmt.Sprintf("cannot compute sharding filter: %s", err))
 		}
 		if sq != nil {
-			filter = bson.D{
-				{
-					Name:  "$and",
-					Value: []bson.D{sq, filter},
-				},
-			}
+			filter = bson.D{{Name: "$and", Value: []bson.D{sq, filter}}}
 		}
 	}
 
 	if m.forcedReadFilter != nil {
-		filter = bson.D{
-			{
-				Name:  "$and",
-				Value: []bson.D{m.forcedReadFilter, filter},
-			},
-		}
+		filter = bson.D{{Name: "$and", Value: []bson.D{m.forcedReadFilter, filter}}}
 	}
 
 	sp := tracing.StartTrace(mctx, fmt.Sprintf("manipmongo.retrieve.object.%s", object.Identity().Name))
@@ -417,12 +407,7 @@ func (m *mongoManipulator) Create(mctx manipulate.Context, object elemental.Iden
 				return manipulate.NewErrCannotBuildQuery(fmt.Sprintf("cannot compute sharding filter: %s", err))
 			}
 			if sq != nil {
-				filter = bson.D{
-					{
-						Name:  "$and",
-						Value: []bson.D{sq, filter},
-					},
-				}
+				filter = bson.D{{Name: "$and", Value: []bson.D{sq, filter}}}
 			}
 		}
 
@@ -520,12 +505,7 @@ func (m *mongoManipulator) Update(mctx manipulate.Context, object elemental.Iden
 			return manipulate.NewErrCannotBuildQuery(fmt.Sprintf("cannot compute sharding filter: %s", err))
 		}
 		if sq != nil {
-			filter = bson.D{
-				{
-					Name:  "$and",
-					Value: []bson.D{sq, filter},
-				},
-			}
+			filter = bson.D{{Name: "$and", Value: []bson.D{sq, filter}}}
 		}
 	}
 
@@ -590,22 +570,12 @@ func (m *mongoManipulator) Delete(mctx manipulate.Context, object elemental.Iden
 			return manipulate.NewErrCannotBuildQuery(fmt.Sprintf("cannot compute sharding filter: %s", err))
 		}
 		if sq != nil {
-			filter = bson.D{
-				{
-					Name:  "$and",
-					Value: []bson.D{sq, filter},
-				},
-			}
+			filter = bson.D{{Name: "$and", Value: []bson.D{sq, filter}}}
 		}
 	}
 
 	if m.forcedReadFilter != nil {
-		filter = bson.D{
-			{
-				Name:  "$and",
-				Value: []bson.D{m.forcedReadFilter, filter},
-			},
-		}
+		filter = bson.D{{Name: "$and", Value: []bson.D{m.forcedReadFilter, filter}}}
 	}
 
 	if _, err := RunQuery(
@@ -657,22 +627,12 @@ func (m *mongoManipulator) DeleteMany(mctx manipulate.Context, identity elementa
 			return manipulate.NewErrCannotBuildQuery(fmt.Sprintf("cannot compute sharding filter: %s", err))
 		}
 		if sq != nil {
-			filter = bson.D{
-				{
-					Name:  "$and",
-					Value: []bson.D{sq, filter},
-				},
-			}
+			filter = bson.D{{Name: "$and", Value: []bson.D{sq, filter}}}
 		}
 	}
 
 	if m.forcedReadFilter != nil {
-		filter = bson.D{
-			{
-				Name:  "$and",
-				Value: []bson.D{m.forcedReadFilter, filter},
-			},
-		}
+		filter = bson.D{{Name: "$and", Value: []bson.D{m.forcedReadFilter, filter}}}
 	}
 
 	if _, err := RunQuery(
@@ -715,22 +675,12 @@ func (m *mongoManipulator) Count(mctx manipulate.Context, identity elemental.Ide
 			return 0, manipulate.NewErrCannotBuildQuery(fmt.Sprintf("cannot compute sharding filter: %s", err))
 		}
 		if sq != nil {
-			filter = bson.D{
-				{
-					Name:  "$and",
-					Value: []bson.D{sq, filter},
-				},
-			}
+			filter = bson.D{{Name: "$and", Value: []bson.D{sq, filter}}}
 		}
 	}
 
 	if m.forcedReadFilter != nil {
-		filter = bson.D{
-			{
-				Name:  "$and",
-				Value: []bson.D{m.forcedReadFilter, filter},
-			},
-		}
+		filter = bson.D{{Name: "$and", Value: []bson.D{m.forcedReadFilter, filter}}}
 	}
 
 	sp := tracing.StartTrace(mctx, fmt.Sprintf("manipmongo.count.%s", identity.Category))

--- a/manipmongo/options.go
+++ b/manipmongo/options.go
@@ -35,7 +35,7 @@ type config struct {
 	writeConsistency   manipulate.WriteConsistency
 	sharder            Sharder
 	defaultRetryFunc   manipulate.RetryFunc
-	forcedReadFilter   bson.M
+	forcedReadFilter   bson.D
 	attributeEncrypter elemental.AttributeEncrypter
 	explain            map[elemental.Identity]map[elemental.Operation]struct{}
 }
@@ -116,9 +116,9 @@ func OptionDefaultRetryFunc(f manipulate.RetryFunc) Option {
 	}
 }
 
-// OptionForceReadFilter allows to set a bson.M filter that
+// OptionForceReadFilter allows to set a bson.D filter that
 // will always reducing the scope of the reads to that filter.
-func OptionForceReadFilter(f bson.M) Option {
+func OptionForceReadFilter(f bson.D) Option {
 	return func(c *config) {
 		c.forcedReadFilter = f
 	}

--- a/manipmongo/options_test.go
+++ b/manipmongo/options_test.go
@@ -31,10 +31,10 @@ func (*fakeSharder) Shard(manipulate.TransactionalManipulator, manipulate.Contex
 func (*fakeSharder) OnShardedWrite(manipulate.TransactionalManipulator, manipulate.Context, elemental.Operation, elemental.Identifiable) error {
 	return nil
 }
-func (*fakeSharder) FilterOne(manipulate.TransactionalManipulator, manipulate.Context, elemental.Identifiable) (bson.M, error) {
+func (*fakeSharder) FilterOne(manipulate.TransactionalManipulator, manipulate.Context, elemental.Identifiable) (bson.D, error) {
 	return nil, nil
 }
-func (*fakeSharder) FilterMany(manipulate.TransactionalManipulator, manipulate.Context, elemental.Identity) (bson.M, error) {
+func (*fakeSharder) FilterMany(manipulate.TransactionalManipulator, manipulate.Context, elemental.Identity) (bson.D, error) {
 	return nil, nil
 }
 
@@ -119,10 +119,10 @@ func Test_Options(t *testing.T) {
 	})
 
 	Convey("Calling OptionForceReadFilter should work", t, func() {
-		f := bson.M{}
+		f := bson.D{}
 		c := newConfig()
 		OptionForceReadFilter(f)(c)
-		So(c.forcedReadFilter, ShouldEqual, f)
+		So(c.forcedReadFilter, ShouldResemble, f)
 	})
 
 	Convey("Calling OptionAttributeEncrypter should work", t, func() {

--- a/manipmongo/sharder.go
+++ b/manipmongo/sharder.go
@@ -35,11 +35,11 @@ type Sharder interface {
 	// used to perform an efficient localized query for a single object.
 	//
 	// You can return nil which will trigger a broadcast.
-	FilterOne(manipulate.TransactionalManipulator, manipulate.Context, elemental.Identifiable) (bson.M, error)
+	FilterOne(manipulate.TransactionalManipulator, manipulate.Context, elemental.Identifiable) (bson.D, error)
 
 	// FilterMany returns the filter bit as bson.M that must be
 	// used to perform an efficient localized query for multiple objects.
 	//
 	// You can return nil which will trigger a broadcast.
-	FilterMany(manipulate.TransactionalManipulator, manipulate.Context, elemental.Identity) (bson.M, error)
+	FilterMany(manipulate.TransactionalManipulator, manipulate.Context, elemental.Identity) (bson.D, error)
 }

--- a/manipmongo/utils.go
+++ b/manipmongo/utils.go
@@ -49,7 +49,7 @@ func applyOrdering(order []string) []string {
 	return o
 }
 
-func prepareNextFilter(collection *mgo.Collection, orderingField string, next string) (bson.M, error) {
+func prepareNextFilter(collection *mgo.Collection, orderingField string, next string) (bson.D, error) {
 
 	var id interface{}
 	if oid, ok := objectid.Parse(next); ok {
@@ -59,7 +59,17 @@ func prepareNextFilter(collection *mgo.Collection, orderingField string, next st
 	}
 
 	if orderingField == "" {
-		return bson.M{"_id": bson.M{"$gt": id}}, nil
+		return bson.D{
+			{
+				Name: "_id",
+				Value: bson.D{
+					{
+						Name:  "$gt",
+						Value: id,
+					},
+				},
+			},
+		}, nil
 	}
 
 	comp := "$gt"
@@ -73,7 +83,17 @@ func prepareNextFilter(collection *mgo.Collection, orderingField string, next st
 		return nil, handleQueryError(err)
 	}
 
-	return bson.M{orderingField: bson.M{comp: doc[orderingField]}}, nil
+	return bson.D{
+		{
+			Name: orderingField,
+			Value: bson.D{
+				{
+					Name:  comp,
+					Value: doc[orderingField],
+				},
+			},
+		},
+	}, nil
 }
 
 func handleQueryError(err error) error {
@@ -232,7 +252,7 @@ func convertWriteConsistency(c manipulate.WriteConsistency) *mgo.Safe {
 
 func explainIfNeeded(
 	query *mgo.Query,
-	filter bson.M,
+	filter bson.D,
 	identity elemental.Identity,
 	operation elemental.Operation,
 	explainMap map[elemental.Identity]map[elemental.Operation]struct{},
@@ -258,7 +278,7 @@ func explainIfNeeded(
 	return nil
 }
 
-func explain(query *mgo.Query, operation elemental.Operation, identity elemental.Identity, filter bson.M) error {
+func explain(query *mgo.Query, operation elemental.Operation, identity elemental.Identity, filter bson.D) error {
 
 	r := bson.M{}
 	if err := query.Explain(&r); err != nil {

--- a/manipmongo/utils_test.go
+++ b/manipmongo/utils_test.go
@@ -588,7 +588,7 @@ func Test_explainIfNeeded(t *testing.T) {
 
 	type args struct {
 		query      *mgo.Query
-		filter     bson.M
+		filter     bson.D
 		identity   elemental.Identity
 		operation  elemental.Operation
 		explainMap map[elemental.Identity]map[elemental.Operation]struct{}


### PR DESCRIPTION

Previously, we were using bson.M which was not preserverving the order, ending up with filters that could bypass indexing.