### PR TITLE
fixed: use bson.D for filters instead of bson.M (#119)

### DIFF
--- a/manipmongo/helpers.go
+++ b/manipmongo/helpers.go
@@ -26,7 +26,7 @@ import (
 )
 
 // CompileFilter compiles the given manipulate filter into a raw mongo filter.
-func CompileFilter(f *elemental.Filter) bson.M {
+func CompileFilter(f *elemental.Filter) bson.D {
 	return compiler.CompileFilter(f)
 }
 

--- a/manipmongo/helpers_test.go
+++ b/manipmongo/helpers_test.go
@@ -36,8 +36,27 @@ func TestCompileFilter(t *testing.T) {
 
 			cf := CompileFilter(f)
 
+			ddd := bson.D{
+				{
+					Name: "$and",
+					Value: []bson.D{
+						{
+							{
+								Name: "a",
+								Value: bson.D{
+									{
+										Name:  "$eq",
+										Value: "b",
+									},
+								},
+							},
+						},
+					},
+				},
+			}
+
 			Convey("Then cf should be correct", func() {
-				So(cf, ShouldResemble, bson.M{"$and": []bson.M{{"a": bson.M{"$eq": "b"}}}})
+				So(cf, ShouldResemble, ddd)
 			})
 		})
 	})

--- a/manipmongo/manipulator.go
+++ b/manipmongo/manipulator.go
@@ -36,7 +36,7 @@ type mongoManipulator struct {
 	dbName             string
 	sharder            Sharder
 	defaultRetryFunc   manipulate.RetryFunc
-	forcedReadFilter   bson.M
+	forcedReadFilter   bson.D
 	attributeEncrypter elemental.AttributeEncrypter
 	explain            map[elemental.Identity]map[elemental.Operation]struct{}
 }
@@ -113,12 +113,12 @@ func (m *mongoManipulator) RetrieveMany(mctx manipulate.Context, dest elemental.
 	}
 
 	// Filtering
-	filter := bson.M{}
+	filter := bson.D{}
 	if f := mctx.Filter(); f != nil {
 		filter = compiler.CompileFilter(f)
 	}
 
-	var ands []bson.M
+	var ands []bson.D
 
 	if m.sharder != nil {
 		sq, err := m.sharder.FilterMany(m, mctx, dest.Identity())
@@ -154,7 +154,7 @@ func (m *mongoManipulator) RetrieveMany(mctx manipulate.Context, dest elemental.
 	}
 
 	if len(ands) > 0 {
-		filter = bson.M{"$and": append(ands, filter)}
+		filter = bson.D{{Name: "$and", Value: append(ands, filter)}}
 	}
 
 	// Query building
@@ -251,16 +251,16 @@ func (m *mongoManipulator) Retrieve(mctx manipulate.Context, object elemental.Id
 	c, close := m.makeSession(object.Identity(), mctx.ReadConsistency(), mctx.WriteConsistency())
 	defer close()
 
-	filter := bson.M{}
+	filter := bson.D{}
 
 	if f := mctx.Filter(); f != nil {
 		filter = compiler.CompileFilter(f)
 	}
 
 	if oid, ok := objectid.Parse(object.Identifier()); ok {
-		filter["_id"] = oid
+		filter = append(filter, bson.DocElem{Name: "_id", Value: oid})
 	} else {
-		filter["_id"] = object.Identifier()
+		filter = append(filter, bson.DocElem{Name: "_id", Value: object.Identifier()})
 	}
 
 	if m.sharder != nil {
@@ -269,12 +269,12 @@ func (m *mongoManipulator) Retrieve(mctx manipulate.Context, object elemental.Id
 			return manipulate.NewErrCannotBuildQuery(fmt.Sprintf("cannot compute sharding filter: %s", err))
 		}
 		if sq != nil {
-			filter = bson.M{"$and": []bson.M{sq, filter}}
+			filter = bson.D{{Name: "$and", Value: []bson.D{sq, filter}}}
 		}
 	}
 
 	if m.forcedReadFilter != nil {
-		filter = bson.M{"$and": []bson.M{m.forcedReadFilter, filter}}
+		filter = bson.D{{Name: "$and", Value: []bson.D{m.forcedReadFilter, filter}}}
 	}
 
 	sp := tracing.StartTrace(mctx, fmt.Sprintf("manipmongo.retrieve.object.%s", object.Identity().Name))
@@ -407,7 +407,7 @@ func (m *mongoManipulator) Create(mctx manipulate.Context, object elemental.Iden
 				return manipulate.NewErrCannotBuildQuery(fmt.Sprintf("cannot compute sharding filter: %s", err))
 			}
 			if sq != nil {
-				filter = bson.M{"$and": []bson.M{sq, filter}}
+				filter = bson.D{{Name: "$and", Value: []bson.D{sq, filter}}}
 			}
 		}
 
@@ -487,16 +487,16 @@ func (m *mongoManipulator) Update(mctx manipulate.Context, object elemental.Iden
 	c, close := m.makeSession(object.Identity(), mctx.ReadConsistency(), mctx.WriteConsistency())
 	defer close()
 
-	var filter bson.M
+	var filter bson.D
 
 	sp := tracing.StartTrace(mctx, fmt.Sprintf("manipmongo.update.object.%s", object.Identity().Name))
 	sp.LogFields(log.String("object_id", object.Identifier()))
 	defer sp.Finish()
 
 	if oid, ok := objectid.Parse(object.Identifier()); ok {
-		filter = bson.M{"_id": oid}
+		filter = append(filter, bson.DocElem{Name: "_id", Value: oid})
 	} else {
-		filter = bson.M{"_id": object.Identifier()}
+		filter = append(filter, bson.DocElem{Name: "_id", Value: object.Identifier()})
 	}
 
 	if m.sharder != nil {
@@ -505,12 +505,17 @@ func (m *mongoManipulator) Update(mctx manipulate.Context, object elemental.Iden
 			return manipulate.NewErrCannotBuildQuery(fmt.Sprintf("cannot compute sharding filter: %s", err))
 		}
 		if sq != nil {
-			filter = bson.M{"$and": []bson.M{sq, filter}}
+			filter = bson.D{{Name: "$and", Value: []bson.D{sq, filter}}}
 		}
 	}
 
 	if m.forcedReadFilter != nil {
-		filter = bson.M{"$and": []bson.M{m.forcedReadFilter, filter}}
+		filter = bson.D{
+			{
+				Name:  "$and",
+				Value: []bson.D{m.forcedReadFilter, filter},
+			},
+		}
 	}
 
 	if _, err := RunQuery(
@@ -547,16 +552,16 @@ func (m *mongoManipulator) Delete(mctx manipulate.Context, object elemental.Iden
 	c, close := m.makeSession(object.Identity(), mctx.ReadConsistency(), mctx.WriteConsistency())
 	defer close()
 
-	var filter bson.M
+	var filter bson.D
 
 	sp := tracing.StartTrace(mctx, fmt.Sprintf("manipmongobject.delete.object.%s", object.Identity().Name))
 	sp.LogFields(log.String("object_id", object.Identifier()))
 	defer sp.Finish()
 
 	if oid, ok := objectid.Parse(object.Identifier()); ok {
-		filter = bson.M{"_id": oid}
+		filter = append(filter, bson.DocElem{Name: "_id", Value: oid})
 	} else {
-		filter = bson.M{"_id": object.Identifier()}
+		filter = append(filter, bson.DocElem{Name: "_id", Value: object.Identifier()})
 	}
 
 	if m.sharder != nil {
@@ -565,12 +570,12 @@ func (m *mongoManipulator) Delete(mctx manipulate.Context, object elemental.Iden
 			return manipulate.NewErrCannotBuildQuery(fmt.Sprintf("cannot compute sharding filter: %s", err))
 		}
 		if sq != nil {
-			filter = bson.M{"$and": []bson.M{sq, filter}}
+			filter = bson.D{{Name: "$and", Value: []bson.D{sq, filter}}}
 		}
 	}
 
 	if m.forcedReadFilter != nil {
-		filter = bson.M{"$and": []bson.M{m.forcedReadFilter, filter}}
+		filter = bson.D{{Name: "$and", Value: []bson.D{m.forcedReadFilter, filter}}}
 	}
 
 	if _, err := RunQuery(
@@ -622,12 +627,12 @@ func (m *mongoManipulator) DeleteMany(mctx manipulate.Context, identity elementa
 			return manipulate.NewErrCannotBuildQuery(fmt.Sprintf("cannot compute sharding filter: %s", err))
 		}
 		if sq != nil {
-			filter = bson.M{"$and": []bson.M{sq, filter}}
+			filter = bson.D{{Name: "$and", Value: []bson.D{sq, filter}}}
 		}
 	}
 
 	if m.forcedReadFilter != nil {
-		filter = bson.M{"$and": []bson.M{m.forcedReadFilter, filter}}
+		filter = bson.D{{Name: "$and", Value: []bson.D{m.forcedReadFilter, filter}}}
 	}
 
 	if _, err := RunQuery(
@@ -658,7 +663,7 @@ func (m *mongoManipulator) Count(mctx manipulate.Context, identity elemental.Ide
 	c, close := m.makeSession(identity, mctx.ReadConsistency(), mctx.WriteConsistency())
 	defer close()
 
-	filter := bson.M{}
+	filter := bson.D{}
 
 	if f := mctx.Filter(); f != nil {
 		filter = compiler.CompileFilter(f)
@@ -670,12 +675,12 @@ func (m *mongoManipulator) Count(mctx manipulate.Context, identity elemental.Ide
 			return 0, manipulate.NewErrCannotBuildQuery(fmt.Sprintf("cannot compute sharding filter: %s", err))
 		}
 		if sq != nil {
-			filter = bson.M{"$and": []bson.M{sq, filter}}
+			filter = bson.D{{Name: "$and", Value: []bson.D{sq, filter}}}
 		}
 	}
 
 	if m.forcedReadFilter != nil {
-		filter = bson.M{"$and": []bson.M{m.forcedReadFilter, filter}}
+		filter = bson.D{{Name: "$and", Value: []bson.D{m.forcedReadFilter, filter}}}
 	}
 
 	sp := tracing.StartTrace(mctx, fmt.Sprintf("manipmongo.count.%s", identity.Category))

--- a/manipmongo/options.go
+++ b/manipmongo/options.go
@@ -35,7 +35,7 @@ type config struct {
 	writeConsistency   manipulate.WriteConsistency
 	sharder            Sharder
 	defaultRetryFunc   manipulate.RetryFunc
-	forcedReadFilter   bson.M
+	forcedReadFilter   bson.D
 	attributeEncrypter elemental.AttributeEncrypter
 	explain            map[elemental.Identity]map[elemental.Operation]struct{}
 }
@@ -116,9 +116,9 @@ func OptionDefaultRetryFunc(f manipulate.RetryFunc) Option {
 	}
 }
 
-// OptionForceReadFilter allows to set a bson.M filter that
+// OptionForceReadFilter allows to set a bson.D filter that
 // will always reducing the scope of the reads to that filter.
-func OptionForceReadFilter(f bson.M) Option {
+func OptionForceReadFilter(f bson.D) Option {
 	return func(c *config) {
 		c.forcedReadFilter = f
 	}

--- a/manipmongo/options_test.go
+++ b/manipmongo/options_test.go
@@ -31,10 +31,10 @@ func (*fakeSharder) Shard(manipulate.TransactionalManipulator, manipulate.Contex
 func (*fakeSharder) OnShardedWrite(manipulate.TransactionalManipulator, manipulate.Context, elemental.Operation, elemental.Identifiable) error {
 	return nil
 }
-func (*fakeSharder) FilterOne(manipulate.TransactionalManipulator, manipulate.Context, elemental.Identifiable) (bson.M, error) {
+func (*fakeSharder) FilterOne(manipulate.TransactionalManipulator, manipulate.Context, elemental.Identifiable) (bson.D, error) {
 	return nil, nil
 }
-func (*fakeSharder) FilterMany(manipulate.TransactionalManipulator, manipulate.Context, elemental.Identity) (bson.M, error) {
+func (*fakeSharder) FilterMany(manipulate.TransactionalManipulator, manipulate.Context, elemental.Identity) (bson.D, error) {
 	return nil, nil
 }
 
@@ -119,10 +119,10 @@ func Test_Options(t *testing.T) {
 	})
 
 	Convey("Calling OptionForceReadFilter should work", t, func() {
-		f := bson.M{}
+		f := bson.D{}
 		c := newConfig()
 		OptionForceReadFilter(f)(c)
-		So(c.forcedReadFilter, ShouldEqual, f)
+		So(c.forcedReadFilter, ShouldResemble, f)
 	})
 
 	Convey("Calling OptionAttributeEncrypter should work", t, func() {

--- a/manipmongo/sharder.go
+++ b/manipmongo/sharder.go
@@ -35,11 +35,11 @@ type Sharder interface {
 	// used to perform an efficient localized query for a single object.
 	//
 	// You can return nil which will trigger a broadcast.
-	FilterOne(manipulate.TransactionalManipulator, manipulate.Context, elemental.Identifiable) (bson.M, error)
+	FilterOne(manipulate.TransactionalManipulator, manipulate.Context, elemental.Identifiable) (bson.D, error)
 
 	// FilterMany returns the filter bit as bson.M that must be
 	// used to perform an efficient localized query for multiple objects.
 	//
 	// You can return nil which will trigger a broadcast.
-	FilterMany(manipulate.TransactionalManipulator, manipulate.Context, elemental.Identity) (bson.M, error)
+	FilterMany(manipulate.TransactionalManipulator, manipulate.Context, elemental.Identity) (bson.D, error)
 }

--- a/manipmongo/utils.go
+++ b/manipmongo/utils.go
@@ -49,7 +49,7 @@ func applyOrdering(order []string) []string {
 	return o
 }
 
-func prepareNextFilter(collection *mgo.Collection, orderingField string, next string) (bson.M, error) {
+func prepareNextFilter(collection *mgo.Collection, orderingField string, next string) (bson.D, error) {
 
 	var id interface{}
 	if oid, ok := objectid.Parse(next); ok {
@@ -59,7 +59,17 @@ func prepareNextFilter(collection *mgo.Collection, orderingField string, next st
 	}
 
 	if orderingField == "" {
-		return bson.M{"_id": bson.M{"$gt": id}}, nil
+		return bson.D{
+			{
+				Name: "_id",
+				Value: bson.D{
+					{
+						Name:  "$gt",
+						Value: id,
+					},
+				},
+			},
+		}, nil
 	}
 
 	comp := "$gt"
@@ -73,7 +83,17 @@ func prepareNextFilter(collection *mgo.Collection, orderingField string, next st
 		return nil, handleQueryError(err)
 	}
 
-	return bson.M{orderingField: bson.M{comp: doc[orderingField]}}, nil
+	return bson.D{
+		{
+			Name: orderingField,
+			Value: bson.D{
+				{
+					Name:  comp,
+					Value: doc[orderingField],
+				},
+			},
+		},
+	}, nil
 }
 
 func handleQueryError(err error) error {
@@ -232,7 +252,7 @@ func convertWriteConsistency(c manipulate.WriteConsistency) *mgo.Safe {
 
 func explainIfNeeded(
 	query *mgo.Query,
-	filter bson.M,
+	filter bson.D,
 	identity elemental.Identity,
 	operation elemental.Operation,
 	explainMap map[elemental.Identity]map[elemental.Operation]struct{},
@@ -258,7 +278,7 @@ func explainIfNeeded(
 	return nil
 }
 
-func explain(query *mgo.Query, operation elemental.Operation, identity elemental.Identity, filter bson.M) error {
+func explain(query *mgo.Query, operation elemental.Operation, identity elemental.Identity, filter bson.D) error {
 
 	r := bson.M{}
 	if err := query.Explain(&r); err != nil {

--- a/manipmongo/utils_test.go
+++ b/manipmongo/utils_test.go
@@ -588,7 +588,7 @@ func Test_explainIfNeeded(t *testing.T) {
 
 	type args struct {
 		query      *mgo.Query
-		filter     bson.M
+		filter     bson.D
 		identity   elemental.Identity
 		operation  elemental.Operation
 		explainMap map[elemental.Identity]map[elemental.Operation]struct{}


### PR DESCRIPTION

Previously, we were using bson.M which was not preserving the order, ending up with filters that could bypass indexing.