### PR TITLE
ManipHttp: Add client TCP_USERTIMEOUT option to the socket.

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -19,4 +19,5 @@ require (
 	go.uber.org/zap v1.14.0
 	golang.org/x/lint v0.0.0-20200130185559-910be7a94367 // indirect
 	golang.org/x/sync v0.0.0-20190911185100-cd5d95a43a6e
+	golang.org/x/sys v0.0.0-20200223170610-d5e6a3e2c0ae
 )

--- a/go.sum
+++ b/go.sum
@@ -242,6 +242,7 @@ golang.org/x/sys v0.0.0-20190215142949-d0b11bdaac8a/go.mod h1:STP8DvDyc/dI5b8T5h
 golang.org/x/sys v0.0.0-20190221075227-b4e8571b14e0/go.mod h1:STP8DvDyc/dI5b8T5hshtkjS+E42TnysNCUPdjciGhY=
 golang.org/x/sys v0.0.0-20190412213103-97732733099d/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20190726091711-fc99dfbffb4e/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
+golang.org/x/sys v0.0.0-20200223170610-d5e6a3e2c0ae h1:/WDfKMnPU+m5M4xB+6x4kaepxRw6jWvR5iDRdvjHgy8=
 golang.org/x/sys v0.0.0-20200223170610-d5e6a3e2c0ae/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/text v0.0.0-20170915032832-14c0d48ead0c/go.mod h1:NqM8EUOU14njkJ3fqMW+pc6Ldnwhi/IjpwHt7yyuwOQ=
 golang.org/x/text v0.3.0/go.mod h1:NqM8EUOU14njkJ3fqMW+pc6Ldnwhi/IjpwHt7yyuwOQ=

--- a/maniphttp/internal/syscall/syscall_linux.go
+++ b/maniphttp/internal/syscall/syscall_linux.go
@@ -18,10 +18,17 @@ const (
 
 // SetTCPUserTimeout sets the TCP timeout for a socket connection
 func SetTCPUserTimeout(t time.Duration) func(string, string, syscall.RawConn) error {
+
+	// return if the tcpUserTimeout is not set.
+	if t == 0 {
+		return nil
+	}
 	tcpTimeout := defaultTCPNetworkTimeout
-	if t != defaultTCPNetworkTimeout {
+
+	if t > 0 && t != defaultTCPNetworkTimeout {
 		tcpTimeout = t
 	}
+
 	return func(network, address string, c syscall.RawConn) error {
 		var sysErr error
 		var err = c.Control(func(fd uintptr) {

--- a/maniphttp/internal/syscall/syscall_linux.go
+++ b/maniphttp/internal/syscall/syscall_linux.go
@@ -1,0 +1,36 @@
+// +build linux
+
+package syscall
+
+// package to set to the low-level/OS settings
+
+import (
+	"os"
+	"syscall"
+	"time"
+
+	"golang.org/x/sys/unix"
+)
+
+const (
+	defaultTCPNetworkTimeout = 30 * time.Second
+)
+
+// SetTCPUserTimeout sets the TCP timeout for a socket connection
+func SetTCPUserTimeout(t time.Duration) func(string, string, syscall.RawConn) error {
+	tcpTimeout := defaultTCPNetworkTimeout
+	if t != defaultTCPNetworkTimeout {
+		tcpTimeout = t
+	}
+	return func(network, address string, c syscall.RawConn) error {
+		var sysErr error
+		var err = c.Control(func(fd uintptr) {
+			sysErr = syscall.SetsockoptInt(int(fd), syscall.SOL_TCP, unix.TCP_USER_TIMEOUT,
+				int(tcpTimeout.Milliseconds()))
+		})
+		if sysErr != nil {
+			return os.NewSyscallError("setsockopt", sysErr)
+		}
+		return err
+	}
+}

--- a/maniphttp/internal/syscall/syscall_linux.go
+++ b/maniphttp/internal/syscall/syscall_linux.go
@@ -12,28 +12,18 @@ import (
 	"golang.org/x/sys/unix"
 )
 
-const (
-	defaultTCPNetworkTimeout = 30 * time.Second
-)
-
-// SetTCPUserTimeout sets the TCP timeout for a socket connection
-func SetTCPUserTimeout(t time.Duration) func(string, string, syscall.RawConn) error {
-
+// MakeDialerControlFunc creates a custom control for the dailer
+func MakeDialerControlFunc(t time.Duration) func(string, string, syscall.RawConn) error {
 	// return if the tcpUserTimeout is not set.
 	if t == 0 {
 		return nil
 	}
-	tcpTimeout := defaultTCPNetworkTimeout
-
-	if t > 0 && t != defaultTCPNetworkTimeout {
-		tcpTimeout = t
-	}
 
 	return func(network, address string, c syscall.RawConn) error {
 		var sysErr error
-		var err = c.Control(func(fd uintptr) {
+		err := c.Control(func(fd uintptr) {
 			sysErr = syscall.SetsockoptInt(int(fd), syscall.SOL_TCP, unix.TCP_USER_TIMEOUT,
-				int(tcpTimeout.Milliseconds()))
+				int(t.Milliseconds()))
 		})
 		if sysErr != nil {
 			return os.NewSyscallError("setsockopt", sysErr)

--- a/maniphttp/internal/syscall/syscall_nonlinux.go
+++ b/maniphttp/internal/syscall/syscall_nonlinux.go
@@ -9,7 +9,7 @@ import (
 
 // package to set to the low-level/OS settings
 
-// SetTCPUserTimeout sets the TCP timeout for a socket connection
-func SetTCPUserTimeout(d time.Duration) func(string, string, syscall.RawConn) error {
+// MakeDialerControlFunc creates a custom control for the dailer
+func MakeDialerControlFunc(d time.Duration) func(string, string, syscall.RawConn) error {
 	return nil
 }

--- a/maniphttp/internal/syscall/syscall_nonlinux.go
+++ b/maniphttp/internal/syscall/syscall_nonlinux.go
@@ -1,0 +1,15 @@
+// +build !linux
+
+package syscall
+
+import (
+	"syscall"
+	"time"
+)
+
+// package to set to the low-level/OS settings
+
+// SetTCPUserTimeout sets the TCP timeout for a socket connection
+func SetTCPUserTimeout(d time.Duration) func(string, string, syscall.RawConn) error {
+	return nil
+}

--- a/maniphttp/manipulator.go
+++ b/maniphttp/manipulator.go
@@ -42,6 +42,7 @@ import (
 const (
 	defaultGlobalContextTimeout = 2 * time.Minute
 	minContextTimeout           = 20 * time.Second
+	defaultTCPNetworkTimeout    = 30 * time.Second
 )
 
 func init() {
@@ -64,13 +65,14 @@ type httpManipulator struct {
 	tokenCookieKey       string
 
 	// optionnable
-	ctx           context.Context
-	client        *http.Client
-	tlsConfig     *tls.Config
-	tokenManager  manipulate.TokenManager
-	globalHeaders http.Header
-	transport     *http.Transport
-	encoding      elemental.EncodingType
+	ctx            context.Context
+	client         *http.Client
+	tlsConfig      *tls.Config
+	tokenManager   manipulate.TokenManager
+	globalHeaders  http.Header
+	transport      *http.Transport
+	encoding       elemental.EncodingType
+	tcpUserTimeout time.Duration
 }
 
 // New returns a maniphttp.Manipulator configured according to the given suite of Option.
@@ -103,7 +105,7 @@ func New(ctx context.Context, url string, options ...Option) (manipulate.Manipul
 
 		if m.transport == nil {
 
-			m.transport, m.url = getDefaultHTTPTransport(url, m.disableCompression)
+			m.transport, m.url = getDefaultHTTPTransport(url, m.disableCompression, m.tcpUserTimeout)
 
 			if m.tlsConfig == nil {
 				m.tlsConfig = getDefaultTLSConfig()

--- a/maniphttp/manipulator.go
+++ b/maniphttp/manipulator.go
@@ -42,7 +42,6 @@ import (
 const (
 	defaultGlobalContextTimeout = 2 * time.Minute
 	minContextTimeout           = 20 * time.Second
-	defaultTCPNetworkTimeout    = 30 * time.Second
 )
 
 func init() {

--- a/maniphttp/manipulator_test.go
+++ b/maniphttp/manipulator_test.go
@@ -93,22 +93,14 @@ func TestHTTP_New(t *testing.T) {
 	})
 
 	Convey("When I create a simple manipulator with custom transport", t, func() {
-		dialer := (&net.Dialer{
-			Timeout:   10 * time.Second,
-			KeepAlive: 30 * time.Second,
-			Control:   internalsyscall.MakeDialerControlFunc(30 * time.Second),
-		}).DialContext
 
-		transport := &http.Transport{
-			DialContext: dialer,
-		}
+		transport := &http.Transport{}
 		transport.TLSClientConfig = &tls.Config{}
 
 		mm, _ := New(
 			context.Background(),
 			"http://url.com/",
 			OptionHTTPTransport(transport),
-			OptionTCPUserTimeout(40*time.Second),
 		)
 
 		m := mm.(*httpManipulator)
@@ -116,97 +108,8 @@ func TestHTTP_New(t *testing.T) {
 		Convey("Then the tls config is correct", func() {
 			So(m.tlsConfig, ShouldEqual, transport.TLSClientConfig)
 		})
-		Convey("Then the dailer is correct", func() {
-			l, err := net.Listen("tcp", "127.0.0.1:8097")
-			So(err, ShouldBeNil)
-
-			opt := -1
-			dctx := m.client.Transport.(*http.Transport).DialContext
-			So(dctx, ShouldNotBeNil)
-			conn, err := dctx(context.TODO(), "tcp", "127.0.0.1:8097")
-			So(err, ShouldBeNil)
-
-			tcpConn, ok := conn.(*net.TCPConn)
-			So(ok, ShouldBeTrue)
-
-			rawConn, err := tcpConn.SyscallConn()
-			So(err, ShouldBeNil)
-
-			err = rawConn.Control(func(fd uintptr) {
-				opt, err = syscall.GetsockoptInt(int(fd), syscall.IPPROTO_TCP, unix.TCP_USER_TIMEOUT)
-			})
-			So(err, ShouldBeNil)
-			So(opt, ShouldEqual, 30*time.Second/time.Millisecond)
-			l.Close() // nolint
-		})
 	})
-	Convey("When I create a simple manipulator with default transport, with TCP_USER_TIMEOUT", t, func() {
-		mm, _ := New(
-			context.Background(),
-			"http://url.com/",
-			OptionTCPUserTimeout(40*time.Second),
-		)
 
-		m := mm.(*httpManipulator)
-
-		Convey("Then the dailer is correct", func() {
-			l, err := net.Listen("tcp", "127.0.0.1:8097")
-			So(err, ShouldBeNil)
-
-			opt := -1
-			dctx := m.client.Transport.(*http.Transport).DialContext
-			So(dctx, ShouldNotBeNil)
-			conn, err := dctx(context.TODO(), "tcp", "127.0.0.1:8097")
-			So(err, ShouldBeNil)
-
-			tcpConn, ok := conn.(*net.TCPConn)
-			So(ok, ShouldBeTrue)
-
-			rawConn, err := tcpConn.SyscallConn()
-			So(err, ShouldBeNil)
-
-			err = rawConn.Control(func(fd uintptr) {
-				opt, err = syscall.GetsockoptInt(int(fd), syscall.IPPROTO_TCP, unix.TCP_USER_TIMEOUT)
-			})
-			So(err, ShouldBeNil)
-			So(opt, ShouldEqual, 40*time.Second/time.Millisecond)
-
-			l.Close() // nolint
-		})
-	})
-	Convey("When I create a simple manipulator with default transport, without TCP_USER_TIMEOUT", t, func() {
-		mm, _ := New(
-			context.Background(),
-			"http://url.com/",
-		)
-
-		m := mm.(*httpManipulator)
-
-		Convey("Then the dailer is correct", func() {
-			l, err := net.Listen("tcp", "127.0.0.1:8097")
-			So(err, ShouldBeNil)
-
-			opt := -1
-			dctx := m.client.Transport.(*http.Transport).DialContext
-			So(dctx, ShouldNotBeNil)
-			conn, err := dctx(context.TODO(), "tcp", "127.0.0.1:8097")
-			So(err, ShouldBeNil)
-
-			tcpConn, ok := conn.(*net.TCPConn)
-			So(ok, ShouldBeTrue)
-
-			rawConn, err := tcpConn.SyscallConn()
-			So(err, ShouldBeNil)
-
-			err = rawConn.Control(func(fd uintptr) {
-				opt, err = syscall.GetsockoptInt(int(fd), syscall.IPPROTO_TCP, unix.TCP_USER_TIMEOUT)
-			})
-			So(err, ShouldBeNil)
-			So(opt, ShouldEqual, 0)
-
-			l.Close() // nolint
-		})
-	})
 	Convey("When I create a simple manipulator with custom client", t, func() {
 
 		transport := &http.Transport{}
@@ -280,6 +183,123 @@ func TestHTTP_New(t *testing.T) {
 	})
 }
 
+func TestHTTP_TCPUserTimeout(t *testing.T) {
+	Convey("When I create a simple manipulator with custom transport, with TCP option", t, func() {
+		dialer := (&net.Dialer{
+			Timeout:   10 * time.Second,
+			KeepAlive: 30 * time.Second,
+			Control:   internalsyscall.MakeDialerControlFunc(30 * time.Second),
+		}).DialContext
+
+		transport := &http.Transport{
+			DialContext: dialer,
+		}
+		transport.TLSClientConfig = &tls.Config{}
+
+		mm, _ := New(
+			context.Background(),
+			"http://url.com/",
+			OptionHTTPTransport(transport),
+			OptionTCPUserTimeout(40*time.Second),
+		)
+
+		m := mm.(*httpManipulator)
+
+		Convey("Then the tls config is correct", func() {
+			So(m.tlsConfig, ShouldEqual, transport.TLSClientConfig)
+		})
+		Convey("Then the dailer is correct", func() {
+			l, err := net.Listen("tcp", ":0")
+			So(err, ShouldBeNil)
+
+			opt := -1
+			dctx := m.client.Transport.(*http.Transport).DialContext
+			So(dctx, ShouldNotBeNil)
+			conn, err := dctx(context.TODO(), "tcp", l.Addr().String())
+			So(err, ShouldBeNil)
+
+			tcpConn, ok := conn.(*net.TCPConn)
+			So(ok, ShouldBeTrue)
+
+			rawConn, err := tcpConn.SyscallConn()
+			So(err, ShouldBeNil)
+
+			err = rawConn.Control(func(fd uintptr) {
+				opt, err = syscall.GetsockoptInt(int(fd), syscall.IPPROTO_TCP, unix.TCP_USER_TIMEOUT)
+			})
+			So(err, ShouldBeNil)
+			So(opt, ShouldEqual, 30*time.Second/time.Millisecond)
+			l.Close() // nolint
+		})
+	})
+	Convey("When I create a simple manipulator with default transport, with TCP_USER_TIMEOUT", t, func() {
+		mm, _ := New(
+			context.Background(),
+			"http://url.com/",
+			OptionTCPUserTimeout(40*time.Second),
+		)
+
+		m := mm.(*httpManipulator)
+
+		Convey("Then the dailer is correct", func() {
+			l, err := net.Listen("tcp", ":0")
+			So(err, ShouldBeNil)
+
+			opt := -1
+			dctx := m.client.Transport.(*http.Transport).DialContext
+			So(dctx, ShouldNotBeNil)
+			conn, err := dctx(context.TODO(), "tcp", l.Addr().String())
+			So(err, ShouldBeNil)
+
+			tcpConn, ok := conn.(*net.TCPConn)
+			So(ok, ShouldBeTrue)
+
+			rawConn, err := tcpConn.SyscallConn()
+			So(err, ShouldBeNil)
+
+			err = rawConn.Control(func(fd uintptr) {
+				opt, err = syscall.GetsockoptInt(int(fd), syscall.IPPROTO_TCP, unix.TCP_USER_TIMEOUT)
+			})
+			So(err, ShouldBeNil)
+			So(opt, ShouldEqual, 40*time.Second/time.Millisecond)
+
+			l.Close() // nolint
+		})
+	})
+	Convey("When I create a simple manipulator with default transport, without TCP_USER_TIMEOUT", t, func() {
+		mm, _ := New(
+			context.Background(),
+			"http://url.com/",
+		)
+
+		m := mm.(*httpManipulator)
+
+		Convey("Then the dailer is correct", func() {
+			l, err := net.Listen("tcp4", ":0")
+			So(err, ShouldBeNil)
+
+			opt := -1
+			dctx := m.client.Transport.(*http.Transport).DialContext
+			So(dctx, ShouldNotBeNil)
+			conn, err := dctx(context.TODO(), "tcp4", l.Addr().String())
+			So(err, ShouldBeNil)
+
+			tcpConn, ok := conn.(*net.TCPConn)
+			So(ok, ShouldBeTrue)
+
+			rawConn, err := tcpConn.SyscallConn()
+			So(err, ShouldBeNil)
+
+			err = rawConn.Control(func(fd uintptr) {
+				opt, err = syscall.GetsockoptInt(int(fd), syscall.IPPROTO_TCP, unix.TCP_USER_TIMEOUT)
+			})
+			So(err, ShouldBeNil)
+			So(opt, ShouldEqual, 0)
+
+			l.Close() // nolint
+		})
+	})
+}
 func TestHTTP_RetrieveMany(t *testing.T) {
 
 	Convey("Given I have a manipulator and a working server", t, func() {

--- a/maniphttp/manipulator_test.go
+++ b/maniphttp/manipulator_test.go
@@ -63,7 +63,7 @@ func TestHTTP_New(t *testing.T) {
 			So(m.namespace, ShouldEqual, "myns")
 		})
 
-		Convey("Then the control dailer should be nil", func() {
+		Convey("Then the control dialer should be nil", func() {
 			So(m.tcpUserTimeout, ShouldEqual, 0)
 		})
 
@@ -208,7 +208,7 @@ func TestHTTP_TCPUserTimeout(t *testing.T) {
 		Convey("Then the tls config is correct", func() {
 			So(m.tlsConfig, ShouldEqual, transport.TLSClientConfig)
 		})
-		Convey("Then the dailer is correct", func() {
+		Convey("Then the dialer is correct", func() {
 			l, err := net.Listen("tcp", ":0")
 			So(err, ShouldBeNil)
 
@@ -241,7 +241,7 @@ func TestHTTP_TCPUserTimeout(t *testing.T) {
 
 		m := mm.(*httpManipulator)
 
-		Convey("Then the dailer is correct", func() {
+		Convey("Then the dialer is correct", func() {
 			l, err := net.Listen("tcp", ":0")
 			So(err, ShouldBeNil)
 
@@ -274,7 +274,7 @@ func TestHTTP_TCPUserTimeout(t *testing.T) {
 
 		m := mm.(*httpManipulator)
 
-		Convey("Then the dailer is correct", func() {
+		Convey("Then the dialer is correct", func() {
 			l, err := net.Listen("tcp4", ":0")
 			So(err, ShouldBeNil)
 

--- a/maniphttp/manipulator_test.go
+++ b/maniphttp/manipulator_test.go
@@ -137,7 +137,7 @@ func TestHTTP_New(t *testing.T) {
 			})
 			So(err, ShouldBeNil)
 			So(opt, ShouldEqual, 30*time.Second/time.Millisecond)
-			l.Close()
+			l.Close() // nolint
 		})
 	})
 	Convey("When I create a simple manipulator with default transport, with TCP_USER_TIMEOUT", t, func() {
@@ -150,7 +150,7 @@ func TestHTTP_New(t *testing.T) {
 		m := mm.(*httpManipulator)
 
 		Convey("Then the dailer is correct", func() {
-			_, err := net.Listen("tcp", "127.0.0.1:80")
+			l, err := net.Listen("tcp", "127.0.0.1:80")
 			So(err, ShouldBeNil)
 
 			opt := -1
@@ -171,6 +171,7 @@ func TestHTTP_New(t *testing.T) {
 			So(err, ShouldBeNil)
 			So(opt, ShouldEqual, 40*time.Second/time.Millisecond)
 
+			l.Close() // nolint
 		})
 	})
 	Convey("When I create a simple manipulator with custom client", t, func() {

--- a/maniphttp/manipulator_test.go
+++ b/maniphttp/manipulator_test.go
@@ -117,13 +117,13 @@ func TestHTTP_New(t *testing.T) {
 			So(m.tlsConfig, ShouldEqual, transport.TLSClientConfig)
 		})
 		Convey("Then the dailer is correct", func() {
-			l, err := net.Listen("tcp", "127.0.0.1:80")
+			l, err := net.Listen("tcp", "127.0.0.1:8097")
 			So(err, ShouldBeNil)
 
 			opt := -1
 			dctx := m.client.Transport.(*http.Transport).DialContext
 			So(dctx, ShouldNotBeNil)
-			conn, err := dctx(context.TODO(), "tcp", "127.0.0.1:80")
+			conn, err := dctx(context.TODO(), "tcp", "127.0.0.1:8097")
 			So(err, ShouldBeNil)
 
 			tcpConn, ok := conn.(*net.TCPConn)
@@ -150,13 +150,13 @@ func TestHTTP_New(t *testing.T) {
 		m := mm.(*httpManipulator)
 
 		Convey("Then the dailer is correct", func() {
-			l, err := net.Listen("tcp", "127.0.0.1:80")
+			l, err := net.Listen("tcp", "127.0.0.1:8097")
 			So(err, ShouldBeNil)
 
 			opt := -1
 			dctx := m.client.Transport.(*http.Transport).DialContext
 			So(dctx, ShouldNotBeNil)
-			conn, err := dctx(context.TODO(), "tcp", "127.0.0.1:80")
+			conn, err := dctx(context.TODO(), "tcp", "127.0.0.1:8097")
 			So(err, ShouldBeNil)
 
 			tcpConn, ok := conn.(*net.TCPConn)

--- a/maniphttp/options.go
+++ b/maniphttp/options.go
@@ -14,6 +14,7 @@ package maniphttp
 import (
 	"crypto/tls"
 	"net/http"
+	"time"
 
 	"go.aporeto.io/elemental"
 	"go.aporeto.io/manipulate"
@@ -153,5 +154,13 @@ func OptionSendCredentialsAsCookie(key string) Option {
 func OptionSimulateFailures(failureSimulations map[float64]error) Option {
 	return func(m *httpManipulator) {
 		m.failureSimulations = failureSimulations
+	}
+}
+
+// OptionTCPUserTimeout configures the manipulator to
+// have a custom tcp user timeout.
+func OptionTCPUserTimeout(t time.Duration) Option {
+	return func(m *httpManipulator) {
+		m.tcpUserTimeout = t
 	}
 }

--- a/maniphttp/options_test.go
+++ b/maniphttp/options_test.go
@@ -16,6 +16,7 @@ import (
 	"crypto/tls"
 	"net/http"
 	"testing"
+	"time"
 
 	. "github.com/smartystreets/goconvey/convey"
 	"go.aporeto.io/elemental"
@@ -120,5 +121,12 @@ func Test_Options(t *testing.T) {
 		m := &httpManipulator{}
 		OptionSendCredentialsAsCookie("x-token")(m)
 		So(m.tokenCookieKey, ShouldEqual, "x-token")
+	})
+
+	Convey("Calling OptionTcpUserTimeout should work", t, func() {
+		m := &httpManipulator{}
+		t := 10 * time.Second
+		OptionTCPUserTimeout(t)(m)
+		So(m.tcpUserTimeout, ShouldEqual, t)
 	})
 }

--- a/maniphttp/utils.go
+++ b/maniphttp/utils.go
@@ -135,7 +135,7 @@ func getDefaultHTTPTransport(url string, disableCompression bool, tcpUserTimeout
 	dialer := (&net.Dialer{
 		Timeout:   10 * time.Second,
 		KeepAlive: 30 * time.Second,
-		Control:   syscall.SetTCPUserTimeout(tcpUserTimeout),
+		Control:   syscall.MakeDialerControlFunc(tcpUserTimeout),
 	}).DialContext
 
 	outURL := url

--- a/maniphttp/utils.go
+++ b/maniphttp/utils.go
@@ -27,6 +27,7 @@ import (
 	"go.aporeto.io/elemental"
 	"go.aporeto.io/manipulate"
 	"go.aporeto.io/manipulate/maniphttp/internal/compiler"
+	"go.aporeto.io/manipulate/maniphttp/internal/syscall"
 )
 
 // AddQueryParameters appends each key-value pair from ctx.Parameters
@@ -129,11 +130,12 @@ func getDefaultTLSConfig() *tls.Config {
 	}
 }
 
-func getDefaultHTTPTransport(url string, disableCompression bool) (*http.Transport, string) {
+func getDefaultHTTPTransport(url string, disableCompression bool, tcpUserTimeout time.Duration) (*http.Transport, string) {
 
 	dialer := (&net.Dialer{
 		Timeout:   10 * time.Second,
 		KeepAlive: 30 * time.Second,
+		Control:   syscall.SetTCPUserTimeout(tcpUserTimeout),
 	}).DialContext
 
 	outURL := url


### PR DESCRIPTION
Issue: Whenever the network connection dies after the handshake, the TCP doesn't kill the connection until it times out, it starts the re-transmission timer and keeps up retrying the packets which leads to the socket buffer being full and wastage of resources. This will happen till TCP timeouts saying there is no ACK far any of the packets, which is default by 15-30 mins, depends on the OS. 

This was observed in one of the Openshift issue: https://github.com/aporeto-inc/aporeto-devs/issues/528

We are still debugging why is the pre-existing connections dropped by eBPF but for now this 

Fix: Add a TCP socket option.


I think this should be always there. Even the golang grpc has this by default. 

