### PR TITLE
impr/maniphttp: Retry in case of broken pipe, reset by peer

### DIFF
--- a/maniphttp/backoff.go
+++ b/maniphttp/backoff.go
@@ -14,9 +14,12 @@ var (
 	}
 
 	strongBackoffCurve = []time.Duration{
-		10 * time.Second,
-		30 * time.Second,
-		60 * time.Second,
+		2 * time.Second,
+		4 * time.Second,
+		8 * time.Second,
+		16 * time.Second,
+		32 * time.Second,
+		64 * time.Second,
 	}
 
 	testingBackoffCurve = []time.Duration{

--- a/maniphttp/backoff.go
+++ b/maniphttp/backoff.go
@@ -1,6 +1,9 @@
 package maniphttp
 
-import "time"
+import (
+	"math/rand"
+	"time"
+)
 
 var (
 	defaultBackoffCurve = []time.Duration{
@@ -14,12 +17,12 @@ var (
 	}
 
 	strongBackoffCurve = []time.Duration{
-		2 * time.Second,
-		4 * time.Second,
-		8 * time.Second,
-		16 * time.Second,
-		32 * time.Second,
-		64 * time.Second,
+		time.Duration(1500+rand.Intn(1000)) * time.Millisecond,  // t in (1.5, 2.5)
+		time.Duration(3000+rand.Intn(1000)) * time.Millisecond,  // t in (3,4)
+		time.Duration(7000+rand.Intn(2000)) * time.Millisecond,  // t in (7,9)
+		time.Duration(14000+rand.Intn(2000)) * time.Millisecond, // t in (14,16)
+		time.Duration(30000+rand.Intn(2000)) * time.Millisecond, // t in (30,32)
+		time.Duration(62000+rand.Intn(2000)) * time.Millisecond, // t in (62, 64)
 	}
 
 	testingBackoffCurve = []time.Duration{

--- a/maniphttp/manipulator.go
+++ b/maniphttp/manipulator.go
@@ -731,15 +731,6 @@ func (s *httpManipulator) send(
 				return nil, manipulate.NewErrTLS(err.Error())
 
 			default:
-
-				// HACK: http.nothingWrittenError is not exposed se we cannot trap that one
-				if fmt.Sprintf("%T", uerr.Err) == "http.nothingWrittenError" {
-					if lastError == nil {
-						lastError = manipulate.NewErrDisconnected(snip.Snip(err, s.currentPassword()).Error())
-					}
-					goto RETRY
-				}
-
 				return nil, manipulate.NewErrCannotExecuteQuery(err.Error())
 			}
 		}

--- a/maniphttp/manipulator.go
+++ b/maniphttp/manipulator.go
@@ -708,10 +708,10 @@ func (s *httpManipulator) send(
 
 				// If we have unerlying op.Error
 				var opErr *net.OpError
-				if errors.As(uerr.Err, opErr) {
+				if errors.As(uerr.Err, &opErr) {
 					// Which leads to a syscallError
 					var syscallErr *os.SyscallError
-					if errors.As(opErr, syscallErr) {
+					if errors.As(opErr, &syscallErr) {
 						// Of type conn reset
 						if errors.Is(syscallErr.Err, syscall.ECONNRESET) {
 							if lastError == nil {

--- a/maniphttp/manipulator_test.go
+++ b/maniphttp/manipulator_test.go
@@ -44,8 +44,8 @@ func (l *hangupListerner) Accept() (net.Conn, error) {
 		return nil, err
 	}
 	// No idea how it works so don't touch it
-	c.(*net.TCPConn).SetNoDelay(true)
-	c.(*net.TCPConn).SetLinger(0)
+	c.(*net.TCPConn).SetNoDelay(true) //nolint
+	c.(*net.TCPConn).SetLinger(0)     //nolint
 	time.Sleep(100 * time.Millisecond)
 	c.Close() //nolint
 	return c, nil

--- a/maniphttp/manipulator_test.go
+++ b/maniphttp/manipulator_test.go
@@ -1035,7 +1035,7 @@ func TestHTTP_send(t *testing.T) {
 		resp, err := m.(*httpManipulator).send(manipulate.NewContext(ctx), http.MethodGet, ts.URL, nil, nil, sp)
 
 		So(err, ShouldNotBeNil)
-		So(err, ShouldHaveSameTypeAs, manipulate.ErrDisconnected{})
+		So(err, ShouldHaveSameTypeAs, manipulate.ErrCannotCommunicate{})
 		So(err.Error(), ShouldEndWith, "connection reset by peer")
 
 		So(resp, ShouldBeNil)

--- a/maniphttp/manipulator_test.go
+++ b/maniphttp/manipulator_test.go
@@ -15,6 +15,7 @@ import (
 	"context"
 	"crypto/tls"
 	"fmt"
+	"net"
 	"net/http"
 	"net/http/httptest"
 	"sync/atomic"
@@ -30,6 +31,41 @@ import (
 	"go.aporeto.io/manipulate/maniptest"
 	"golang.org/x/sync/errgroup"
 )
+
+// hangupListerner is a tcp listener that will close upon accept
+type hangupListerner struct {
+	net.Listener
+}
+
+func (l *hangupListerner) Accept() (net.Conn, error) {
+
+	c, err := l.Listener.Accept()
+	if err != nil {
+		return nil, err
+	}
+	// No idea how it works so don't touch it
+	c.(*net.TCPConn).SetNoDelay(true)
+	c.(*net.TCPConn).SetLinger(0)
+	time.Sleep(100 * time.Millisecond)
+	c.Close() //nolint
+	return c, nil
+}
+
+func (l *hangupListerner) Addr() net.Addr {
+	return l.Listener.Addr()
+}
+
+func (l *hangupListerner) Close() error {
+	return l.Listener.Close()
+}
+
+func newHangupListerner() net.Listener {
+	l, err := net.Listen("tcp", "127.0.0.1:0")
+	if err != nil {
+		panic(err)
+	}
+	return &hangupListerner{l}
+}
 
 func TestHTTP_New(t *testing.T) {
 
@@ -974,6 +1010,37 @@ func TestHTTP_send(t *testing.T) {
 	sp := tracing.StartTrace(nil, "test")
 	defer sp.Finish()
 
+	Convey("Given I have a server returning connection reset by peer due to tcp close", t, func() {
+
+		ts := httptest.Server{
+			Listener: newHangupListerner(),
+			Config:   &http.Server{Handler: http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {})},
+		}
+		ts.Start()
+		defer ts.Close()
+
+		m, err := New(
+			context.Background(),
+			ts.URL,
+			OptionBackoffCurve(testingBackoffCurve),
+			OptionStrongBackoffCurve(testingBackoffCurve),
+		)
+		if err != nil {
+			panic(err)
+		}
+
+		ctx, cancel := context.WithTimeout(context.Background(), 1*time.Second)
+		defer cancel()
+
+		resp, err := m.(*httpManipulator).send(manipulate.NewContext(ctx), http.MethodGet, ts.URL, nil, nil, sp)
+
+		So(err, ShouldNotBeNil)
+		So(err, ShouldHaveSameTypeAs, manipulate.ErrDisconnected{})
+		So(err.Error(), ShouldEndWith, "connection reset by peer")
+
+		So(resp, ShouldBeNil)
+	})
+
 	Convey("Given I have a m with bad url", t, func() {
 
 		m, _ := New(
@@ -1137,7 +1204,6 @@ func TestHTTP_send(t *testing.T) {
 
 	Convey("Given I have a server and a retry func that returns a error at try 3", t, func() {
 
-		// LALALAL
 		m, _ := New(
 			context.Background(),
 			"toto.com",


### PR DESCRIPTION
This is an attempt to trap the tcp close we can have in case of tcp rate limiting.

As we are trying to optimize the rate limiting at the gateway level, upon tcp closing, the `syscall.ECONNRESET` as a net.OpError is raised(`connection reset by peer`). We are intercepting that event to move the retry to the strong retry curve.

