### PR TITLE
fixed: context.Canceled should use ErrDisconected

### DIFF
--- a/maniphttp/manipulator.go
+++ b/maniphttp/manipulator.go
@@ -690,6 +690,9 @@ func (s *httpManipulator) send(
 			// We check for constant errors.
 			switch uerr.Err {
 
+			case context.Canceled:
+				return nil, manipulate.NewErrDisconnected("Client left")
+
 			case context.DeadlineExceeded:
 				if lastError == nil {
 					lastError = manipulate.NewErrCannotCommunicate(snip.Snip(err, s.currentPassword()).Error())


### PR DESCRIPTION
This patch fixes the handling of `context.Canceled` in maniphttp. It is now returning a `manipulate.ErrDisconnected` that was designed for this, but was never used.