### PR TITLE
issue-791: include server payload on StatusLocked

### DIFF
--- a/errors.go
+++ b/errors.go
@@ -158,7 +158,7 @@ func IsCannotCommunicateError(err error) bool {
 // ErrLocked represents the error returned when the server api is locked..
 type ErrLocked struct{ message string }
 
-// NewErrLocked returns a new ErrCannotCommunicate.
+// NewErrLocked returns a new ErrLocked.
 func NewErrLocked(message string) ErrLocked {
 	return ErrLocked{message: message}
 }

--- a/maniphttp/manipulator_test.go
+++ b/maniphttp/manipulator_test.go
@@ -1097,8 +1097,7 @@ func TestHTTP_send(t *testing.T) {
 		So(err, ShouldNotBeNil)
 		So(err, ShouldHaveSameTypeAs, manipulate.ErrCannotCommunicate{})
 
-		// On linux, the message is slightly different than on macOS
-		So(err.Error(), ShouldStartWith, `Cannot communicate: Post "https://NANANAN": dial tcp: lookup NANANAN`)
+		So(err.Error(), ShouldStartWith, `Cannot communicate: Post "https://NANANAN":`)
 
 		So(resp, ShouldBeNil)
 
@@ -1675,7 +1674,7 @@ func TestHTTP_send(t *testing.T) {
 
 		So(err, ShouldNotBeNil)
 		So(err, ShouldHaveSameTypeAs, manipulate.ErrLocked{})
-		So(err.Error(), ShouldEqual, "Cannot communicate: The api has been locked down by the server.")
+		So(err.Error(), ShouldContainSubstring, "Cannot communicate: The api has been locked down by the server")
 
 		So(resp, ShouldBeNil)
 


### PR DESCRIPTION
We were seeing errors: 
{"l":"fatal","t":"2020-09-17T02:37:29.858Z","m":"Unable to retrieve enforcer configuration","mPid":13842,"error":"unable to retrieve data path certificate: Cannot communicate: The api has been locked down by the server."}

But losing the server reason, i.e. the payload message that indicated why the server returned `http.StatusLocked`

This patch attempts to save the server payload at the time of the error. 

Caveat: 
This patch only concerns itself with `http.StatusLocked` in the RETRY loop.  The other errors in that loop are less likely to have server payloads, but this patch could be generalized to cover all errors and attempt to extract  any payload it can.