### PR TITLE
new: start migration to support error wrapping

### DIFF
--- a/errors.go
+++ b/errors.go
@@ -17,6 +17,7 @@ import "fmt"
 type ErrCannotUnmarshal struct{ Err error }
 
 // NewErrCannotUnmarshal returns a new ErrCannotUnmarshal.
+// Deprecated: this method is deprecated and should not be used anymore.
 func NewErrCannotUnmarshal(message string) ErrCannotUnmarshal {
 	fmt.Println("DEPRECATED: This function is deprecated. Please use simple constructor")
 	return ErrCannotUnmarshal{Err: fmt.Errorf("%s", message)}
@@ -35,6 +36,7 @@ func IsCannotUnmarshalError(err error) bool {
 type ErrCannotMarshal struct{ Err error }
 
 // NewErrCannotMarshal returns a new ErrCannotMarshal.
+// Deprecated: this method is deprecated and should not be used anymore.
 func NewErrCannotMarshal(message string) ErrCannotMarshal {
 	fmt.Println("DEPRECATED: This function is deprecated. Please use simple constructor")
 	return ErrCannotMarshal{Err: fmt.Errorf("%s", message)}
@@ -53,6 +55,7 @@ func IsCannotMarshalError(err error) bool {
 type ErrObjectNotFound struct{ Err error }
 
 // NewErrObjectNotFound returns a new ErrObjectNotFound.
+// Deprecated: this method is deprecated and should not be used anymore.
 func NewErrObjectNotFound(message string) ErrObjectNotFound {
 	fmt.Println("DEPRECATED: This function is deprecated. Please use simple constructor")
 	return ErrObjectNotFound{Err: fmt.Errorf("%s", message)}
@@ -71,6 +74,7 @@ func IsObjectNotFoundError(err error) bool {
 type ErrMultipleObjectsFound struct{ Err error }
 
 // NewErrMultipleObjectsFound returns a new ErrMultipleObjectsFound.
+// Deprecated: this method is deprecated and should not be used anymore.
 func NewErrMultipleObjectsFound(message string) ErrMultipleObjectsFound {
 	fmt.Println("DEPRECATED: This function is deprecated. Please use simple constructor")
 	return ErrMultipleObjectsFound{Err: fmt.Errorf("%s", message)}
@@ -89,6 +93,7 @@ func IsMultipleObjectsFoundError(err error) bool {
 type ErrCannotBuildQuery struct{ Err error }
 
 // NewErrCannotBuildQuery returns a new ErrCannotBuildQuery.
+// Deprecated: this method is deprecated and should not be used anymore.
 func NewErrCannotBuildQuery(message string) ErrCannotBuildQuery {
 	fmt.Println("DEPRECATED: This function is deprecated. Please use simple constructor")
 	return ErrCannotBuildQuery{Err: fmt.Errorf("%s", message)}
@@ -107,6 +112,7 @@ func IsCannotBuildQueryError(err error) bool {
 type ErrCannotExecuteQuery struct{ Err error }
 
 // NewErrCannotExecuteQuery returns a new ErrCannotExecuteQuery.
+// Deprecated: this method is deprecated and should not be used anymore.
 func NewErrCannotExecuteQuery(message string) ErrCannotExecuteQuery {
 	fmt.Println("DEPRECATED: This function is deprecated. Please use simple constructor")
 	return ErrCannotExecuteQuery{Err: fmt.Errorf("%s", message)}
@@ -125,6 +131,7 @@ func IsCannotExecuteQueryError(err error) bool {
 type ErrCannotCommit struct{ Err error }
 
 // NewErrCannotCommit returns a new ErrCannotCommit.
+// Deprecated: this method is deprecated and should not be used anymore.
 func NewErrCannotCommit(message string) ErrCannotCommit {
 	fmt.Println("DEPRECATED: This function is deprecated. Please use simple constructor")
 	return ErrCannotCommit{Err: fmt.Errorf("%s", message)}
@@ -143,6 +150,7 @@ func IsCannotCommitError(err error) bool {
 type ErrNotImplemented struct{ Err error }
 
 // NewErrNotImplemented returns a new ErrNotImplemented.
+// Deprecated: this method is deprecated and should not be used anymore.
 func NewErrNotImplemented(message string) ErrNotImplemented {
 	fmt.Println("DEPRECATED: This function is deprecated. Please use simple constructor")
 	return ErrNotImplemented{Err: fmt.Errorf("%s", message)}
@@ -161,6 +169,7 @@ func IsNotImplementedError(err error) bool {
 type ErrCannotCommunicate struct{ Err error }
 
 // NewErrCannotCommunicate returns a new ErrCannotCommunicate.
+// Deprecated: this method is deprecated and should not be used anymore.
 func NewErrCannotCommunicate(message string) ErrCannotCommunicate {
 	fmt.Println("DEPRECATED: This function is deprecated. Please use simple constructor")
 	return ErrCannotCommunicate{Err: fmt.Errorf("%s", message)}
@@ -179,6 +188,7 @@ func IsCannotCommunicateError(err error) bool {
 type ErrLocked struct{ Err error }
 
 // NewErrLocked returns a new ErrCannotCommunicate.
+// Deprecated: this method is deprecated and should not be used anymore.
 func NewErrLocked(message string) ErrLocked {
 	fmt.Println("DEPRECATED: This function is deprecated. Please use simple constructor")
 	return ErrLocked{Err: fmt.Errorf("%s", message)}
@@ -197,6 +207,7 @@ func IsLockedError(err error) bool {
 type ErrTransactionNotFound struct{ Err error }
 
 // NewErrTransactionNotFound returns a new ErrTransactionNotFound.
+// Deprecated: this method is deprecated and should not be used anymore.
 func NewErrTransactionNotFound(message string) ErrTransactionNotFound {
 	fmt.Println("DEPRECATED: This function is deprecated. Please use simple constructor")
 	return ErrTransactionNotFound{Err: fmt.Errorf("%s", message)}
@@ -215,6 +226,7 @@ func IsTransactionNotFoundError(err error) bool {
 type ErrConstraintViolation struct{ Err error }
 
 // NewErrConstraintViolation returns a new ErrConstraintViolation.
+// Deprecated: this method is deprecated and should not be used anymore.
 func NewErrConstraintViolation(message string) ErrConstraintViolation {
 	fmt.Println("DEPRECATED: This function is deprecated. Please use simple constructor")
 	return ErrConstraintViolation{Err: fmt.Errorf("%s", message)}
@@ -233,6 +245,7 @@ func IsConstraintViolationError(err error) bool {
 type ErrDisconnected struct{ Err error }
 
 // NewErrDisconnected returns a new ErrDisconnected.
+// Deprecated: this method is deprecated and should not be used anymore.
 func NewErrDisconnected(message string) ErrDisconnected {
 	fmt.Println("DEPRECATED: This function is deprecated. Please use simple constructor")
 	return ErrDisconnected{Err: fmt.Errorf("%s", message)}
@@ -251,6 +264,7 @@ func IsDisconnectedError(err error) bool {
 type ErrTooManyRequests struct{ Err error }
 
 // NewErrTooManyRequests returns a new ErrTooManyRequests.
+// Deprecated: this method is deprecated and should not be used anymore.
 func NewErrTooManyRequests(message string) ErrTooManyRequests {
 	fmt.Println("DEPRECATED: This function is deprecated. Please use simple constructor")
 	return ErrTooManyRequests{Err: fmt.Errorf("%s", message)}
@@ -269,6 +283,7 @@ func IsTooManyRequestsError(err error) bool {
 type ErrTLS struct{ Err error }
 
 // NewErrTLS returns a new ErrTLS.
+// Deprecated: this method is deprecated and should not be used anymore.
 func NewErrTLS(message string) ErrTLS {
 	fmt.Println("DEPRECATED: This function is deprecated. Please use simple constructor")
 	return ErrTLS{Err: fmt.Errorf("%s", message)}

--- a/errors.go
+++ b/errors.go
@@ -23,7 +23,9 @@ func NewErrCannotUnmarshal(message string) ErrCannotUnmarshal {
 	return ErrCannotUnmarshal{Err: fmt.Errorf("%s", message)}
 }
 
+// Unwrap unwraps the internal error.
 func (e ErrCannotUnmarshal) Unwrap() error { return e.Err }
+
 func (e ErrCannotUnmarshal) Error() string { return "Unable to unmarshal data: " + e.Err.Error() }
 
 // IsCannotUnmarshalError returns true if the given error is am ErrCannotUnmarshal.
@@ -42,7 +44,9 @@ func NewErrCannotMarshal(message string) ErrCannotMarshal {
 	return ErrCannotMarshal{Err: fmt.Errorf("%s", message)}
 }
 
+// Unwrap unwraps the internal error.
 func (e ErrCannotMarshal) Unwrap() error { return e.Err }
+
 func (e ErrCannotMarshal) Error() string { return "Unable to marshal data: " + e.Err.Error() }
 
 // IsCannotMarshalError returns true if the given error is am ErrCannotMarshal.
@@ -61,7 +65,9 @@ func NewErrObjectNotFound(message string) ErrObjectNotFound {
 	return ErrObjectNotFound{Err: fmt.Errorf("%s", message)}
 }
 
+// Unwrap unwraps the internal error.
 func (e ErrObjectNotFound) Unwrap() error { return e.Err }
+
 func (e ErrObjectNotFound) Error() string { return "Object not found: " + e.Err.Error() }
 
 // IsObjectNotFoundError returns true if the given error is am ErrObjectNotFound.
@@ -80,7 +86,9 @@ func NewErrMultipleObjectsFound(message string) ErrMultipleObjectsFound {
 	return ErrMultipleObjectsFound{Err: fmt.Errorf("%s", message)}
 }
 
+// Unwrap unwraps the internal error.
 func (e ErrMultipleObjectsFound) Unwrap() error { return e.Err }
+
 func (e ErrMultipleObjectsFound) Error() string { return "Multiple objects found: " + e.Err.Error() }
 
 // IsMultipleObjectsFoundError returns true if the given error is am ErrMultipleObjectsFound.
@@ -99,7 +107,9 @@ func NewErrCannotBuildQuery(message string) ErrCannotBuildQuery {
 	return ErrCannotBuildQuery{Err: fmt.Errorf("%s", message)}
 }
 
+// Unwrap unwraps the internal error.
 func (e ErrCannotBuildQuery) Unwrap() error { return e.Err }
+
 func (e ErrCannotBuildQuery) Error() string { return "Unable to build query: " + e.Err.Error() }
 
 // IsCannotBuildQueryError returns true if the given error is am ErrCannotBuildQuery.
@@ -118,7 +128,9 @@ func NewErrCannotExecuteQuery(message string) ErrCannotExecuteQuery {
 	return ErrCannotExecuteQuery{Err: fmt.Errorf("%s", message)}
 }
 
+// Unwrap unwraps the internal error.
 func (e ErrCannotExecuteQuery) Unwrap() error { return e.Err }
+
 func (e ErrCannotExecuteQuery) Error() string { return "Unable to execute query: " + e.Err.Error() }
 
 // IsCannotExecuteQueryError returns true if the given error is am ErrCannotExecuteQuery.
@@ -137,7 +149,9 @@ func NewErrCannotCommit(message string) ErrCannotCommit {
 	return ErrCannotCommit{Err: fmt.Errorf("%s", message)}
 }
 
+// Unwrap unwraps the internal error.
 func (e ErrCannotCommit) Unwrap() error { return e.Err }
+
 func (e ErrCannotCommit) Error() string { return "Unable to commit transaction: " + e.Err.Error() }
 
 // IsCannotCommitError returns true if the given error is am ErrCannotCommit.
@@ -156,7 +170,9 @@ func NewErrNotImplemented(message string) ErrNotImplemented {
 	return ErrNotImplemented{Err: fmt.Errorf("%s", message)}
 }
 
+// Unwrap unwraps the internal error.
 func (e ErrNotImplemented) Unwrap() error { return e.Err }
+
 func (e ErrNotImplemented) Error() string { return "Not implemented: " + e.Err.Error() }
 
 // IsNotImplementedError returns true if the given error is am ErrNotImplemented.
@@ -175,7 +191,9 @@ func NewErrCannotCommunicate(message string) ErrCannotCommunicate {
 	return ErrCannotCommunicate{Err: fmt.Errorf("%s", message)}
 }
 
+// Unwrap unwraps the internal error.
 func (e ErrCannotCommunicate) Unwrap() error { return e.Err }
+
 func (e ErrCannotCommunicate) Error() string { return "Cannot communicate: " + e.Err.Error() }
 
 // IsCannotCommunicateError returns true if the given error is am ErrCannotCommunicate.
@@ -194,7 +212,9 @@ func NewErrLocked(message string) ErrLocked {
 	return ErrLocked{Err: fmt.Errorf("%s", message)}
 }
 
+// Unwrap unwraps the internal error.
 func (e ErrLocked) Unwrap() error { return e.Err }
+
 func (e ErrLocked) Error() string { return "Cannot communicate: " + e.Err.Error() }
 
 // IsLockedError returns true if the given error is am ErrLocked.
@@ -213,7 +233,9 @@ func NewErrTransactionNotFound(message string) ErrTransactionNotFound {
 	return ErrTransactionNotFound{Err: fmt.Errorf("%s", message)}
 }
 
+// Unwrap unwraps the internal error.
 func (e ErrTransactionNotFound) Unwrap() error { return e.Err }
+
 func (e ErrTransactionNotFound) Error() string { return "Transaction not found: " + e.Err.Error() }
 
 // IsTransactionNotFoundError returns true if the given error is am ErrTransactionNotFound.
@@ -232,7 +254,9 @@ func NewErrConstraintViolation(message string) ErrConstraintViolation {
 	return ErrConstraintViolation{Err: fmt.Errorf("%s", message)}
 }
 
+// Unwrap unwraps the internal error.
 func (e ErrConstraintViolation) Unwrap() error { return e.Err }
+
 func (e ErrConstraintViolation) Error() string { return "Constraint violation: " + e.Err.Error() }
 
 // IsConstraintViolationError returns true if the given error is am ErrConstraintViolation.
@@ -251,7 +275,9 @@ func NewErrDisconnected(message string) ErrDisconnected {
 	return ErrDisconnected{Err: fmt.Errorf("%s", message)}
 }
 
+// Unwrap unwraps the internal error.
 func (e ErrDisconnected) Unwrap() error { return e.Err }
+
 func (e ErrDisconnected) Error() string { return "Disconnected: " + e.Err.Error() }
 
 // IsDisconnectedError returns true if the given error is am ErrDisconnected.
@@ -270,7 +296,9 @@ func NewErrTooManyRequests(message string) ErrTooManyRequests {
 	return ErrTooManyRequests{Err: fmt.Errorf("%s", message)}
 }
 
+// Unwrap unwraps the internal error.
 func (e ErrTooManyRequests) Unwrap() error { return e.Err }
+
 func (e ErrTooManyRequests) Error() string { return "Too many requests: " + e.Err.Error() }
 
 // IsTooManyRequestsError returns true if the given error is am ErrTooManyRequests.
@@ -289,7 +317,9 @@ func NewErrTLS(message string) ErrTLS {
 	return ErrTLS{Err: fmt.Errorf("%s", message)}
 }
 
+// Unwrap unwraps the internal error.
 func (e ErrTLS) Unwrap() error { return e.Err }
+
 func (e ErrTLS) Error() string { return "TLS error: " + e.Err.Error() }
 
 // IsTLSError returns true if the given error is am ErrTLS.

--- a/errors.go
+++ b/errors.go
@@ -11,15 +11,19 @@
 
 package manipulate
 
+import "fmt"
+
 // ErrCannotUnmarshal represents unmarshaling error.
-type ErrCannotUnmarshal struct{ message string }
+type ErrCannotUnmarshal struct{ Err error }
 
 // NewErrCannotUnmarshal returns a new ErrCannotUnmarshal.
 func NewErrCannotUnmarshal(message string) ErrCannotUnmarshal {
-	return ErrCannotUnmarshal{message: message}
+	fmt.Println("DEPRECATED: This function is deprecated. Please use simple constructor")
+	return ErrCannotUnmarshal{Err: fmt.Errorf("%s", message)}
 }
 
-func (e ErrCannotUnmarshal) Error() string { return "Unable to unmarshal data: " + e.message }
+func (e ErrCannotUnmarshal) Unwrap() error { return e.Err }
+func (e ErrCannotUnmarshal) Error() string { return "Unable to unmarshal data: " + e.Err.Error() }
 
 // IsCannotUnmarshalError returns true if the given error is am ErrCannotUnmarshal.
 func IsCannotUnmarshalError(err error) bool {
@@ -28,14 +32,16 @@ func IsCannotUnmarshalError(err error) bool {
 }
 
 // ErrCannotMarshal represents marshaling error.
-type ErrCannotMarshal struct{ message string }
+type ErrCannotMarshal struct{ Err error }
 
 // NewErrCannotMarshal returns a new ErrCannotMarshal.
 func NewErrCannotMarshal(message string) ErrCannotMarshal {
-	return ErrCannotMarshal{message: message}
+	fmt.Println("DEPRECATED: This function is deprecated. Please use simple constructor")
+	return ErrCannotMarshal{Err: fmt.Errorf("%s", message)}
 }
 
-func (e ErrCannotMarshal) Error() string { return "Unable to marshal data: " + e.message }
+func (e ErrCannotMarshal) Unwrap() error { return e.Err }
+func (e ErrCannotMarshal) Error() string { return "Unable to marshal data: " + e.Err.Error() }
 
 // IsCannotMarshalError returns true if the given error is am ErrCannotMarshal.
 func IsCannotMarshalError(err error) bool {
@@ -44,14 +50,16 @@ func IsCannotMarshalError(err error) bool {
 }
 
 // ErrObjectNotFound represents object not found error.
-type ErrObjectNotFound struct{ message string }
+type ErrObjectNotFound struct{ Err error }
 
 // NewErrObjectNotFound returns a new ErrObjectNotFound.
 func NewErrObjectNotFound(message string) ErrObjectNotFound {
-	return ErrObjectNotFound{message: message}
+	fmt.Println("DEPRECATED: This function is deprecated. Please use simple constructor")
+	return ErrObjectNotFound{Err: fmt.Errorf("%s", message)}
 }
 
-func (e ErrObjectNotFound) Error() string { return "Object not found: " + e.message }
+func (e ErrObjectNotFound) Unwrap() error { return e.Err }
+func (e ErrObjectNotFound) Error() string { return "Object not found: " + e.Err.Error() }
 
 // IsObjectNotFoundError returns true if the given error is am ErrObjectNotFound.
 func IsObjectNotFoundError(err error) bool {
@@ -60,14 +68,16 @@ func IsObjectNotFoundError(err error) bool {
 }
 
 // ErrMultipleObjectsFound represents too many object found error.
-type ErrMultipleObjectsFound struct{ message string }
+type ErrMultipleObjectsFound struct{ Err error }
 
 // NewErrMultipleObjectsFound returns a new ErrMultipleObjectsFound.
 func NewErrMultipleObjectsFound(message string) ErrMultipleObjectsFound {
-	return ErrMultipleObjectsFound{message: message}
+	fmt.Println("DEPRECATED: This function is deprecated. Please use simple constructor")
+	return ErrMultipleObjectsFound{Err: fmt.Errorf("%s", message)}
 }
 
-func (e ErrMultipleObjectsFound) Error() string { return "Multiple objects found: " + e.message }
+func (e ErrMultipleObjectsFound) Unwrap() error { return e.Err }
+func (e ErrMultipleObjectsFound) Error() string { return "Multiple objects found: " + e.Err.Error() }
 
 // IsMultipleObjectsFoundError returns true if the given error is am ErrMultipleObjectsFound.
 func IsMultipleObjectsFoundError(err error) bool {
@@ -76,14 +86,16 @@ func IsMultipleObjectsFoundError(err error) bool {
 }
 
 // ErrCannotBuildQuery represents query building error.
-type ErrCannotBuildQuery struct{ message string }
+type ErrCannotBuildQuery struct{ Err error }
 
 // NewErrCannotBuildQuery returns a new ErrCannotBuildQuery.
 func NewErrCannotBuildQuery(message string) ErrCannotBuildQuery {
-	return ErrCannotBuildQuery{message: message}
+	fmt.Println("DEPRECATED: This function is deprecated. Please use simple constructor")
+	return ErrCannotBuildQuery{Err: fmt.Errorf("%s", message)}
 }
 
-func (e ErrCannotBuildQuery) Error() string { return "Unable to build query: " + e.message }
+func (e ErrCannotBuildQuery) Unwrap() error { return e.Err }
+func (e ErrCannotBuildQuery) Error() string { return "Unable to build query: " + e.Err.Error() }
 
 // IsCannotBuildQueryError returns true if the given error is am ErrCannotBuildQuery.
 func IsCannotBuildQueryError(err error) bool {
@@ -92,14 +104,16 @@ func IsCannotBuildQueryError(err error) bool {
 }
 
 // ErrCannotExecuteQuery represents query execution error.
-type ErrCannotExecuteQuery struct{ message string }
+type ErrCannotExecuteQuery struct{ Err error }
 
 // NewErrCannotExecuteQuery returns a new ErrCannotExecuteQuery.
 func NewErrCannotExecuteQuery(message string) ErrCannotExecuteQuery {
-	return ErrCannotExecuteQuery{message: message}
+	fmt.Println("DEPRECATED: This function is deprecated. Please use simple constructor")
+	return ErrCannotExecuteQuery{Err: fmt.Errorf("%s", message)}
 }
 
-func (e ErrCannotExecuteQuery) Error() string { return "Unable to execute query: " + e.message }
+func (e ErrCannotExecuteQuery) Unwrap() error { return e.Err }
+func (e ErrCannotExecuteQuery) Error() string { return "Unable to execute query: " + e.Err.Error() }
 
 // IsCannotExecuteQueryError returns true if the given error is am ErrCannotExecuteQuery.
 func IsCannotExecuteQueryError(err error) bool {
@@ -108,14 +122,16 @@ func IsCannotExecuteQueryError(err error) bool {
 }
 
 // ErrCannotCommit represents commit execution error.
-type ErrCannotCommit struct{ message string }
+type ErrCannotCommit struct{ Err error }
 
 // NewErrCannotCommit returns a new ErrCannotCommit.
 func NewErrCannotCommit(message string) ErrCannotCommit {
-	return ErrCannotCommit{message: message}
+	fmt.Println("DEPRECATED: This function is deprecated. Please use simple constructor")
+	return ErrCannotCommit{Err: fmt.Errorf("%s", message)}
 }
 
-func (e ErrCannotCommit) Error() string { return "Unable to commit transaction: " + e.message }
+func (e ErrCannotCommit) Unwrap() error { return e.Err }
+func (e ErrCannotCommit) Error() string { return "Unable to commit transaction: " + e.Err.Error() }
 
 // IsCannotCommitError returns true if the given error is am ErrCannotCommit.
 func IsCannotCommitError(err error) bool {
@@ -124,14 +140,16 @@ func IsCannotCommitError(err error) bool {
 }
 
 // ErrNotImplemented represents a non implemented function.
-type ErrNotImplemented struct{ message string }
+type ErrNotImplemented struct{ Err error }
 
 // NewErrNotImplemented returns a new ErrNotImplemented.
 func NewErrNotImplemented(message string) ErrNotImplemented {
-	return ErrNotImplemented{message: message}
+	fmt.Println("DEPRECATED: This function is deprecated. Please use simple constructor")
+	return ErrNotImplemented{Err: fmt.Errorf("%s", message)}
 }
 
-func (e ErrNotImplemented) Error() string { return "Not implemented: " + e.message }
+func (e ErrNotImplemented) Unwrap() error { return e.Err }
+func (e ErrNotImplemented) Error() string { return "Not implemented: " + e.Err.Error() }
 
 // IsNotImplementedError returns true if the given error is am ErrNotImplemented.
 func IsNotImplementedError(err error) bool {
@@ -140,14 +158,16 @@ func IsNotImplementedError(err error) bool {
 }
 
 // ErrCannotCommunicate represents a failure in backend communication.
-type ErrCannotCommunicate struct{ message string }
+type ErrCannotCommunicate struct{ Err error }
 
 // NewErrCannotCommunicate returns a new ErrCannotCommunicate.
 func NewErrCannotCommunicate(message string) ErrCannotCommunicate {
-	return ErrCannotCommunicate{message: message}
+	fmt.Println("DEPRECATED: This function is deprecated. Please use simple constructor")
+	return ErrCannotCommunicate{Err: fmt.Errorf("%s", message)}
 }
 
-func (e ErrCannotCommunicate) Error() string { return "Cannot communicate: " + e.message }
+func (e ErrCannotCommunicate) Unwrap() error { return e.Err }
+func (e ErrCannotCommunicate) Error() string { return "Cannot communicate: " + e.Err.Error() }
 
 // IsCannotCommunicateError returns true if the given error is am ErrCannotCommunicate.
 func IsCannotCommunicateError(err error) bool {
@@ -156,14 +176,16 @@ func IsCannotCommunicateError(err error) bool {
 }
 
 // ErrLocked represents the error returned when the server api is locked..
-type ErrLocked struct{ message string }
+type ErrLocked struct{ Err error }
 
 // NewErrLocked returns a new ErrCannotCommunicate.
 func NewErrLocked(message string) ErrLocked {
-	return ErrLocked{message: message}
+	fmt.Println("DEPRECATED: This function is deprecated. Please use simple constructor")
+	return ErrLocked{Err: fmt.Errorf("%s", message)}
 }
 
-func (e ErrLocked) Error() string { return "Cannot communicate: " + e.message }
+func (e ErrLocked) Unwrap() error { return e.Err }
+func (e ErrLocked) Error() string { return "Cannot communicate: " + e.Err.Error() }
 
 // IsLockedError returns true if the given error is am ErrLocked.
 func IsLockedError(err error) bool {
@@ -172,14 +194,16 @@ func IsLockedError(err error) bool {
 }
 
 // ErrTransactionNotFound represents a failure to find a transaction.
-type ErrTransactionNotFound struct{ message string }
+type ErrTransactionNotFound struct{ Err error }
 
 // NewErrTransactionNotFound returns a new ErrTransactionNotFound.
 func NewErrTransactionNotFound(message string) ErrTransactionNotFound {
-	return ErrTransactionNotFound{message: message}
+	fmt.Println("DEPRECATED: This function is deprecated. Please use simple constructor")
+	return ErrTransactionNotFound{Err: fmt.Errorf("%s", message)}
 }
 
-func (e ErrTransactionNotFound) Error() string { return "Transaction not found: " + e.message }
+func (e ErrTransactionNotFound) Unwrap() error { return e.Err }
+func (e ErrTransactionNotFound) Error() string { return "Transaction not found: " + e.Err.Error() }
 
 // IsTransactionNotFoundError returns true if the given error is am ErrTransactionNotFound.
 func IsTransactionNotFoundError(err error) bool {
@@ -188,14 +212,16 @@ func IsTransactionNotFoundError(err error) bool {
 }
 
 // ErrConstraintViolation represents a failure to find a transaction.
-type ErrConstraintViolation struct{ message string }
+type ErrConstraintViolation struct{ Err error }
 
 // NewErrConstraintViolation returns a new ErrConstraintViolation.
 func NewErrConstraintViolation(message string) ErrConstraintViolation {
-	return ErrConstraintViolation{message: message}
+	fmt.Println("DEPRECATED: This function is deprecated. Please use simple constructor")
+	return ErrConstraintViolation{Err: fmt.Errorf("%s", message)}
 }
 
-func (e ErrConstraintViolation) Error() string { return "Constraint violation: " + e.message }
+func (e ErrConstraintViolation) Unwrap() error { return e.Err }
+func (e ErrConstraintViolation) Error() string { return "Constraint violation: " + e.Err.Error() }
 
 // IsConstraintViolationError returns true if the given error is am ErrConstraintViolation.
 func IsConstraintViolationError(err error) bool {
@@ -204,14 +230,16 @@ func IsConstraintViolationError(err error) bool {
 }
 
 // ErrDisconnected represents an error due user disconnection.
-type ErrDisconnected struct{ message string }
+type ErrDisconnected struct{ Err error }
 
 // NewErrDisconnected returns a new ErrDisconnected.
 func NewErrDisconnected(message string) ErrDisconnected {
-	return ErrDisconnected{message: message}
+	fmt.Println("DEPRECATED: This function is deprecated. Please use simple constructor")
+	return ErrDisconnected{Err: fmt.Errorf("%s", message)}
 }
 
-func (e ErrDisconnected) Error() string { return "Disconnected: " + e.message }
+func (e ErrDisconnected) Unwrap() error { return e.Err }
+func (e ErrDisconnected) Error() string { return "Disconnected: " + e.Err.Error() }
 
 // IsDisconnectedError returns true if the given error is am ErrDisconnected.
 func IsDisconnectedError(err error) bool {
@@ -220,14 +248,16 @@ func IsDisconnectedError(err error) bool {
 }
 
 // ErrTooManyRequests represents the error returned when the server api is locked.
-type ErrTooManyRequests struct{ message string }
+type ErrTooManyRequests struct{ Err error }
 
 // NewErrTooManyRequests returns a new ErrTooManyRequests.
 func NewErrTooManyRequests(message string) ErrTooManyRequests {
-	return ErrTooManyRequests{message: message}
+	fmt.Println("DEPRECATED: This function is deprecated. Please use simple constructor")
+	return ErrTooManyRequests{Err: fmt.Errorf("%s", message)}
 }
 
-func (e ErrTooManyRequests) Error() string { return "Too many requests: " + e.message }
+func (e ErrTooManyRequests) Unwrap() error { return e.Err }
+func (e ErrTooManyRequests) Error() string { return "Too many requests: " + e.Err.Error() }
 
 // IsTooManyRequestsError returns true if the given error is am ErrTooManyRequests.
 func IsTooManyRequestsError(err error) bool {
@@ -236,14 +266,16 @@ func IsTooManyRequestsError(err error) bool {
 }
 
 // ErrTLS represents the error returned when there is a TLS error.
-type ErrTLS struct{ message string }
+type ErrTLS struct{ Err error }
 
 // NewErrTLS returns a new ErrTLS.
 func NewErrTLS(message string) ErrTLS {
-	return ErrTLS{message: message}
+	fmt.Println("DEPRECATED: This function is deprecated. Please use simple constructor")
+	return ErrTLS{Err: fmt.Errorf("%s", message)}
 }
 
-func (e ErrTLS) Error() string { return "TLS error: " + e.message }
+func (e ErrTLS) Unwrap() error { return e.Err }
+func (e ErrTLS) Error() string { return "TLS error: " + e.Err.Error() }
 
 // IsTLSError returns true if the given error is am ErrTLS.
 func IsTLSError(err error) bool {

--- a/errors_test.go
+++ b/errors_test.go
@@ -11,134 +11,160 @@
 
 package manipulate
 
-import (
-	"testing"
+// import (
+// 	"errors"
+// 	"fmt"
+// 	"testing"
 
-	. "github.com/smartystreets/goconvey/convey"
-)
+// 	. "github.com/smartystreets/goconvey/convey"
+// )
 
-func genericErrorTest(
-	t *testing.T,
-	errorPrefix string,
-	makeFactory func(string) error,
-	verifierFunc func(error) bool,
-) {
+// func genericErrorTest(
+// 	t *testing.T,
+// 	errorPrefix string,
+// 	makeFactory func(error) error,
+// 	makeFactoryOld func(string) error,
+// 	verifierFunc func(error) bool,
+// ) {
 
-	Convey("When I create an error", t, func() {
+// 	Convey("When I create an error", t, func() {
 
-		err := makeFactory("this is a an error")
+// 		oerr := fmt.Errorf("this is a an error")
+// 		err := makeFactory(oerr)
 
-		Convey("Then it should be correct", func() {
-			So(err.Error(), ShouldEqual, errorPrefix+"this is a an error")
-			So(verifierFunc(err), ShouldBeTrue)
-		})
-	})
-}
+// 		Convey("Then it should be correct", func() {
+// 			So(err.Error(), ShouldEqual, errorPrefix+"this is a an error")
+// 			So(errors.Is(err, oerr), ShouldBeTrue)
+// 			So(verifierFunc(err), ShouldBeTrue)
+// 		})
 
-func TestThing_Function(t *testing.T) {
+// 		olderr := makeFactoryOld("this is a an error")
+// 		Convey("Then the old error should be correct", func() {
+// 			So(olderr.Error(), ShouldEqual, errorPrefix+"this is a an error")
+// 			So(verifierFunc(err), ShouldBeTrue)
+// 		})
+// 	})
+// }
 
-	genericErrorTest(
-		t,
-		"Unable to unmarshal data: ",
-		func(text string) error { return NewErrCannotUnmarshal(text) },
-		IsCannotUnmarshalError,
-	)
+// func TestThing_Function(t *testing.T) {
 
-	genericErrorTest(
-		t,
-		"Unable to marshal data: ",
-		func(text string) error { return NewErrCannotMarshal(text) },
-		IsCannotMarshalError,
-	)
+// 	genericErrorTest(
+// 		t,
+// 		"Unable to unmarshal data: ",
+// 		func(err error) error { return ErrCannotUnmarshal{Err: err} },
+// 		func(msg string) error { return NewErrCannotUnmarshal(msg) },
+// 		IsCannotUnmarshalError,
+// 	)
 
-	genericErrorTest(
-		t,
-		"Object not found: ",
-		func(text string) error { return NewErrObjectNotFound(text) },
-		IsObjectNotFoundError,
-	)
+// 	genericErrorTest(
+// 		t,
+// 		"Unable to marshal data: ",
+// 		func(err error) error { return ErrCannotMarshal{Err: err} },
+// 		func(msg string) error { return NewErrCannotMarshal(msg) },
+// 		IsCannotMarshalError,
+// 	)
 
-	genericErrorTest(
-		t,
-		"Multiple objects found: ",
-		func(text string) error { return NewErrMultipleObjectsFound(text) },
-		IsMultipleObjectsFoundError,
-	)
+// 	genericErrorTest(
+// 		t,
+// 		"Object not found: ",
+// 		func(err error) error { return ErrObjectNotFound{Err: err} },
+// 		func(msg string) error { return NewErrObjectNotFound(msg) },
+// 		IsObjectNotFoundError,
+// 	)
 
-	genericErrorTest(
-		t,
-		"Unable to build query: ",
-		func(text string) error { return NewErrCannotBuildQuery(text) },
-		IsCannotBuildQueryError,
-	)
+// 	genericErrorTest(
+// 		t,
+// 		"Multiple objects found: ",
+// 		func(err error) error { return ErrMultipleObjectsFound{Err: err} },
+// 		func(msg string) error { return NewErrMultipleObjectsFound(msg) },
+// 		IsMultipleObjectsFoundError,
+// 	)
 
-	genericErrorTest(
-		t,
-		"Unable to execute query: ",
-		func(text string) error { return NewErrCannotExecuteQuery(text) },
-		IsCannotExecuteQueryError,
-	)
+// 	genericErrorTest(
+// 		t,
+// 		"Unable to build query: ",
+// 		func(err error) error { return ErrCannotBuildQuery{Err: err} },
+// 		func(msg string) error { return NewErrCannotBuildQuery(msg) },
+// 		IsCannotBuildQueryError,
+// 	)
 
-	genericErrorTest(
-		t,
-		"Unable to commit transaction: ",
-		func(text string) error { return NewErrCannotCommit(text) },
-		IsCannotCommitError,
-	)
+// 	genericErrorTest(
+// 		t,
+// 		"Unable to execute query: ",
+// 		func(err error) error { return ErrCannotExecuteQuery{Err: err} },
+// 		func(msg string) error { return NewErrCannotExecuteQuery(msg) },
+// 		IsCannotExecuteQueryError,
+// 	)
 
-	genericErrorTest(
-		t,
-		"Not implemented: ",
-		func(text string) error { return NewErrNotImplemented(text) },
-		IsNotImplementedError,
-	)
+// 	genericErrorTest(
+// 		t,
+// 		"Unable to commit transaction: ",
+// 		func(err error) error { return ErrCannotCommit{Err: err} },
+// 		func(msg string) error { return NewErrCannotCommit(msg) },
+// 		IsCannotCommitError,
+// 	)
 
-	genericErrorTest(
-		t,
-		"Cannot communicate: ",
-		func(text string) error { return NewErrCannotCommunicate(text) },
-		IsCannotCommunicateError,
-	)
+// 	genericErrorTest(
+// 		t,
+// 		"Not implemented: ",
+// 		func(err error) error { return ErrNotImplemented{Err: err} },
+// 		func(msg string) error { return NewErrNotImplemented(msg) },
+// 		IsNotImplementedError,
+// 	)
 
-	genericErrorTest(
-		t,
-		"Cannot communicate: ",
-		func(text string) error { return NewErrLocked(text) },
-		IsLockedError,
-	)
+// 	genericErrorTest(
+// 		t,
+// 		"Cannot communicate: ",
+// 		func(err error) error { return ErrCannotCommunicate{Err: err} },
+// 		func(msg string) error { return NewErrCannotCommunicate(msg) },
+// 		IsCannotCommunicateError,
+// 	)
 
-	genericErrorTest(
-		t,
-		"Transaction not found: ",
-		func(text string) error { return NewErrTransactionNotFound(text) },
-		IsTransactionNotFoundError,
-	)
+// 	genericErrorTest(
+// 		t,
+// 		"Cannot communicate: ",
+// 		func(err error) error { return ErrLocked{Err: err} },
+// 		func(msg string) error { return NewErrLocked(msg) },
+// 		IsLockedError,
+// 	)
 
-	genericErrorTest(
-		t,
-		"Constraint violation: ",
-		func(text string) error { return NewErrConstraintViolation(text) },
-		IsConstraintViolationError,
-	)
+// 	genericErrorTest(
+// 		t,
+// 		"Transaction not found: ",
+// 		func(err error) error { return ErrTransactionNotFound{Err: err} },
+// 		func(msg string) error { return NewErrTransactionNotFound(msg) },
+// 		IsTransactionNotFoundError,
+// 	)
 
-	genericErrorTest(
-		t,
-		"Disconnected: ",
-		func(text string) error { return NewErrDisconnected(text) },
-		IsDisconnectedError,
-	)
+// 	genericErrorTest(
+// 		t,
+// 		"Constraint violation: ",
+// 		func(err error) error { return ErrConstraintViolation{Err: err} },
+// 		func(msg string) error { return NewErrConstraintViolation(msg) },
+// 		IsConstraintViolationError,
+// 	)
 
-	genericErrorTest(
-		t,
-		"Too many requests: ",
-		func(text string) error { return NewErrTooManyRequests(text) },
-		IsTooManyRequestsError,
-	)
+// 	genericErrorTest(
+// 		t,
+// 		"Disconnected: ",
+// 		func(err error) error { return ErrDisconnected{Err: err} },
+// 		func(msg string) error { return NewErrDisconnected(msg) },
+// 		IsDisconnectedError,
+// 	)
 
-	genericErrorTest(
-		t,
-		"TLS error: ",
-		func(text string) error { return NewErrTLS(text) },
-		IsTLSError,
-	)
-}
+// 	genericErrorTest(
+// 		t,
+// 		"Too many requests: ",
+// 		func(err error) error { return ErrTooManyRequests{Err: err} },
+// 		func(msg string) error { return NewErrTooManyRequests(msg) },
+// 		IsTooManyRequestsError,
+// 	)
+
+// 	genericErrorTest(
+// 		t,
+// 		"TLS error: ",
+// 		func(err error) error { return ErrTLS{Err: err} },
+// 		func(msg string) error { return NewErrTLS(msg) },
+// 		IsTLSError,
+// 	)
+// }

--- a/errors_test.go
+++ b/errors_test.go
@@ -11,160 +11,160 @@
 
 package manipulate
 
-// import (
-// 	"errors"
-// 	"fmt"
-// 	"testing"
+import (
+	"errors"
+	"fmt"
+	"testing"
 
-// 	. "github.com/smartystreets/goconvey/convey"
-// )
+	. "github.com/smartystreets/goconvey/convey"
+)
 
-// func genericErrorTest(
-// 	t *testing.T,
-// 	errorPrefix string,
-// 	makeFactory func(error) error,
-// 	makeFactoryOld func(string) error,
-// 	verifierFunc func(error) bool,
-// ) {
+func genericErrorTest(
+	t *testing.T,
+	errorPrefix string,
+	makeFactory func(error) error,
+	makeFactoryOld func(string) error,
+	verifierFunc func(error) bool,
+) {
 
-// 	Convey("When I create an error", t, func() {
+	Convey("When I create an error", t, func() {
 
-// 		oerr := fmt.Errorf("this is a an error")
-// 		err := makeFactory(oerr)
+		oerr := fmt.Errorf("this is a an error")
+		err := makeFactory(oerr)
 
-// 		Convey("Then it should be correct", func() {
-// 			So(err.Error(), ShouldEqual, errorPrefix+"this is a an error")
-// 			So(errors.Is(err, oerr), ShouldBeTrue)
-// 			So(verifierFunc(err), ShouldBeTrue)
-// 		})
+		Convey("Then it should be correct", func() {
+			So(err.Error(), ShouldEqual, errorPrefix+"this is a an error")
+			So(errors.Is(err, oerr), ShouldBeTrue)
+			So(verifierFunc(err), ShouldBeTrue)
+		})
 
-// 		olderr := makeFactoryOld("this is a an error")
-// 		Convey("Then the old error should be correct", func() {
-// 			So(olderr.Error(), ShouldEqual, errorPrefix+"this is a an error")
-// 			So(verifierFunc(err), ShouldBeTrue)
-// 		})
-// 	})
-// }
+		olderr := makeFactoryOld("this is a an error")
+		Convey("Then the old error should be correct", func() {
+			So(olderr.Error(), ShouldEqual, errorPrefix+"this is a an error")
+			So(verifierFunc(err), ShouldBeTrue)
+		})
+	})
+}
 
-// func TestThing_Function(t *testing.T) {
+func TestThing_Function(t *testing.T) {
 
-// 	genericErrorTest(
-// 		t,
-// 		"Unable to unmarshal data: ",
-// 		func(err error) error { return ErrCannotUnmarshal{Err: err} },
-// 		func(msg string) error { return NewErrCannotUnmarshal(msg) },
-// 		IsCannotUnmarshalError,
-// 	)
+	genericErrorTest(
+		t,
+		"Unable to unmarshal data: ",
+		func(err error) error { return ErrCannotUnmarshal{Err: err} },
+		func(msg string) error { return NewErrCannotUnmarshal(msg) },
+		IsCannotUnmarshalError,
+	)
 
-// 	genericErrorTest(
-// 		t,
-// 		"Unable to marshal data: ",
-// 		func(err error) error { return ErrCannotMarshal{Err: err} },
-// 		func(msg string) error { return NewErrCannotMarshal(msg) },
-// 		IsCannotMarshalError,
-// 	)
+	genericErrorTest(
+		t,
+		"Unable to marshal data: ",
+		func(err error) error { return ErrCannotMarshal{Err: err} },
+		func(msg string) error { return NewErrCannotMarshal(msg) },
+		IsCannotMarshalError,
+	)
 
-// 	genericErrorTest(
-// 		t,
-// 		"Object not found: ",
-// 		func(err error) error { return ErrObjectNotFound{Err: err} },
-// 		func(msg string) error { return NewErrObjectNotFound(msg) },
-// 		IsObjectNotFoundError,
-// 	)
+	genericErrorTest(
+		t,
+		"Object not found: ",
+		func(err error) error { return ErrObjectNotFound{Err: err} },
+		func(msg string) error { return NewErrObjectNotFound(msg) },
+		IsObjectNotFoundError,
+	)
 
-// 	genericErrorTest(
-// 		t,
-// 		"Multiple objects found: ",
-// 		func(err error) error { return ErrMultipleObjectsFound{Err: err} },
-// 		func(msg string) error { return NewErrMultipleObjectsFound(msg) },
-// 		IsMultipleObjectsFoundError,
-// 	)
+	genericErrorTest(
+		t,
+		"Multiple objects found: ",
+		func(err error) error { return ErrMultipleObjectsFound{Err: err} },
+		func(msg string) error { return NewErrMultipleObjectsFound(msg) },
+		IsMultipleObjectsFoundError,
+	)
 
-// 	genericErrorTest(
-// 		t,
-// 		"Unable to build query: ",
-// 		func(err error) error { return ErrCannotBuildQuery{Err: err} },
-// 		func(msg string) error { return NewErrCannotBuildQuery(msg) },
-// 		IsCannotBuildQueryError,
-// 	)
+	genericErrorTest(
+		t,
+		"Unable to build query: ",
+		func(err error) error { return ErrCannotBuildQuery{Err: err} },
+		func(msg string) error { return NewErrCannotBuildQuery(msg) },
+		IsCannotBuildQueryError,
+	)
 
-// 	genericErrorTest(
-// 		t,
-// 		"Unable to execute query: ",
-// 		func(err error) error { return ErrCannotExecuteQuery{Err: err} },
-// 		func(msg string) error { return NewErrCannotExecuteQuery(msg) },
-// 		IsCannotExecuteQueryError,
-// 	)
+	genericErrorTest(
+		t,
+		"Unable to execute query: ",
+		func(err error) error { return ErrCannotExecuteQuery{Err: err} },
+		func(msg string) error { return NewErrCannotExecuteQuery(msg) },
+		IsCannotExecuteQueryError,
+	)
 
-// 	genericErrorTest(
-// 		t,
-// 		"Unable to commit transaction: ",
-// 		func(err error) error { return ErrCannotCommit{Err: err} },
-// 		func(msg string) error { return NewErrCannotCommit(msg) },
-// 		IsCannotCommitError,
-// 	)
+	genericErrorTest(
+		t,
+		"Unable to commit transaction: ",
+		func(err error) error { return ErrCannotCommit{Err: err} },
+		func(msg string) error { return NewErrCannotCommit(msg) },
+		IsCannotCommitError,
+	)
 
-// 	genericErrorTest(
-// 		t,
-// 		"Not implemented: ",
-// 		func(err error) error { return ErrNotImplemented{Err: err} },
-// 		func(msg string) error { return NewErrNotImplemented(msg) },
-// 		IsNotImplementedError,
-// 	)
+	genericErrorTest(
+		t,
+		"Not implemented: ",
+		func(err error) error { return ErrNotImplemented{Err: err} },
+		func(msg string) error { return NewErrNotImplemented(msg) },
+		IsNotImplementedError,
+	)
 
-// 	genericErrorTest(
-// 		t,
-// 		"Cannot communicate: ",
-// 		func(err error) error { return ErrCannotCommunicate{Err: err} },
-// 		func(msg string) error { return NewErrCannotCommunicate(msg) },
-// 		IsCannotCommunicateError,
-// 	)
+	genericErrorTest(
+		t,
+		"Cannot communicate: ",
+		func(err error) error { return ErrCannotCommunicate{Err: err} },
+		func(msg string) error { return NewErrCannotCommunicate(msg) },
+		IsCannotCommunicateError,
+	)
 
-// 	genericErrorTest(
-// 		t,
-// 		"Cannot communicate: ",
-// 		func(err error) error { return ErrLocked{Err: err} },
-// 		func(msg string) error { return NewErrLocked(msg) },
-// 		IsLockedError,
-// 	)
+	genericErrorTest(
+		t,
+		"Cannot communicate: ",
+		func(err error) error { return ErrLocked{Err: err} },
+		func(msg string) error { return NewErrLocked(msg) },
+		IsLockedError,
+	)
 
-// 	genericErrorTest(
-// 		t,
-// 		"Transaction not found: ",
-// 		func(err error) error { return ErrTransactionNotFound{Err: err} },
-// 		func(msg string) error { return NewErrTransactionNotFound(msg) },
-// 		IsTransactionNotFoundError,
-// 	)
+	genericErrorTest(
+		t,
+		"Transaction not found: ",
+		func(err error) error { return ErrTransactionNotFound{Err: err} },
+		func(msg string) error { return NewErrTransactionNotFound(msg) },
+		IsTransactionNotFoundError,
+	)
 
-// 	genericErrorTest(
-// 		t,
-// 		"Constraint violation: ",
-// 		func(err error) error { return ErrConstraintViolation{Err: err} },
-// 		func(msg string) error { return NewErrConstraintViolation(msg) },
-// 		IsConstraintViolationError,
-// 	)
+	genericErrorTest(
+		t,
+		"Constraint violation: ",
+		func(err error) error { return ErrConstraintViolation{Err: err} },
+		func(msg string) error { return NewErrConstraintViolation(msg) },
+		IsConstraintViolationError,
+	)
 
-// 	genericErrorTest(
-// 		t,
-// 		"Disconnected: ",
-// 		func(err error) error { return ErrDisconnected{Err: err} },
-// 		func(msg string) error { return NewErrDisconnected(msg) },
-// 		IsDisconnectedError,
-// 	)
+	genericErrorTest(
+		t,
+		"Disconnected: ",
+		func(err error) error { return ErrDisconnected{Err: err} },
+		func(msg string) error { return NewErrDisconnected(msg) },
+		IsDisconnectedError,
+	)
 
-// 	genericErrorTest(
-// 		t,
-// 		"Too many requests: ",
-// 		func(err error) error { return ErrTooManyRequests{Err: err} },
-// 		func(msg string) error { return NewErrTooManyRequests(msg) },
-// 		IsTooManyRequestsError,
-// 	)
+	genericErrorTest(
+		t,
+		"Too many requests: ",
+		func(err error) error { return ErrTooManyRequests{Err: err} },
+		func(msg string) error { return NewErrTooManyRequests(msg) },
+		IsTooManyRequestsError,
+	)
 
-// 	genericErrorTest(
-// 		t,
-// 		"TLS error: ",
-// 		func(err error) error { return ErrTLS{Err: err} },
-// 		func(msg string) error { return NewErrTLS(msg) },
-// 		IsTLSError,
-// 	)
-// }
+	genericErrorTest(
+		t,
+		"TLS error: ",
+		func(err error) error { return ErrTLS{Err: err} },
+		func(msg string) error { return NewErrTLS(msg) },
+		IsTLSError,
+	)
+}

--- a/internal/push/utils.go
+++ b/internal/push/utils.go
@@ -30,11 +30,11 @@ func decodeErrors(r io.Reader, encoding elemental.EncodingType) error {
 
 	data, err := ioutil.ReadAll(r)
 	if err != nil {
-		return manipulate.ErrCannotUnmarshal{Err: fmt.Errorf("%s: %s", err.Error(), string(data))}
+		return manipulate.ErrCannotUnmarshal{Err: fmt.Errorf("%w: %s", err, string(data))}
 	}
 
 	if err := elemental.Decode(encoding, data, &es); err != nil {
-		return manipulate.ErrCannotUnmarshal{Err: fmt.Errorf("%s: %s", err.Error(), string(data))}
+		return manipulate.ErrCannotUnmarshal{Err: fmt.Errorf("%w: %s", err, string(data))}
 	}
 
 	errs := elemental.NewErrors()

--- a/internal/push/utils.go
+++ b/internal/push/utils.go
@@ -30,11 +30,11 @@ func decodeErrors(r io.Reader, encoding elemental.EncodingType) error {
 
 	data, err := ioutil.ReadAll(r)
 	if err != nil {
-		return manipulate.NewErrCannotUnmarshal(fmt.Sprintf("%s: %s", err.Error(), string(data)))
+		return manipulate.ErrCannotUnmarshal{Err: fmt.Errorf("%s: %s", err.Error(), string(data))}
 	}
 
 	if err := elemental.Decode(encoding, data, &es); err != nil {
-		return manipulate.NewErrCannotUnmarshal(fmt.Sprintf("%s: %s", err.Error(), string(data)))
+		return manipulate.ErrCannotUnmarshal{Err: fmt.Errorf("%s: %s", err.Error(), string(data))}
 	}
 
 	errs := elemental.NewErrors()

--- a/maniphttp/manipulator.go
+++ b/maniphttp/manipulator.go
@@ -164,7 +164,7 @@ func New(ctx context.Context, url string, options ...Option) (manipulate.Manipul
 func (s *httpManipulator) RetrieveMany(mctx manipulate.Context, dest elemental.Identifiables) error {
 
 	if dest == nil {
-		return manipulate.NewErrCannotBuildQuery("nil dest")
+		return manipulate.ErrCannotBuildQuery{Err: fmt.Errorf("nil dest")}
 	}
 
 	if mctx == nil {
@@ -180,7 +180,7 @@ func (s *httpManipulator) RetrieveMany(mctx manipulate.Context, dest elemental.I
 	if err != nil {
 		sp.SetTag("error", true)
 		sp.LogFields(log.Error(err))
-		return manipulate.NewErrCannotBuildQuery(err.Error())
+		return manipulate.ErrCannotBuildQuery{Err: err}
 	}
 
 	response, err := s.send(mctx, http.MethodGet, url, nil, dest, sp)
@@ -207,7 +207,7 @@ func (s *httpManipulator) RetrieveMany(mctx manipulate.Context, dest elemental.I
 func (s *httpManipulator) Retrieve(mctx manipulate.Context, object elemental.Identifiable) error {
 
 	if object == nil {
-		return manipulate.NewErrCannotBuildQuery("nil object")
+		return manipulate.ErrCannotBuildQuery{Err: fmt.Errorf("nil object")}
 	}
 
 	if mctx == nil {
@@ -223,7 +223,7 @@ func (s *httpManipulator) Retrieve(mctx manipulate.Context, object elemental.Ide
 	if err != nil {
 		sp.SetTag("error", true)
 		sp.LogFields(log.Error(err))
-		return manipulate.NewErrCannotBuildQuery(err.Error())
+		return manipulate.ErrCannotBuildQuery{Err: err}
 	}
 
 	response, err := s.send(mctx, http.MethodGet, url, nil, object, sp)
@@ -248,7 +248,7 @@ func (s *httpManipulator) Retrieve(mctx manipulate.Context, object elemental.Ide
 func (s *httpManipulator) Create(mctx manipulate.Context, object elemental.Identifiable) error {
 
 	if object == nil {
-		return manipulate.NewErrCannotBuildQuery("nil object")
+		return manipulate.ErrCannotBuildQuery{Err: fmt.Errorf("nil object")}
 	}
 
 	if mctx == nil {
@@ -270,14 +270,14 @@ func (s *httpManipulator) Create(mctx manipulate.Context, object elemental.Ident
 	if err != nil {
 		sp.SetTag("error", true)
 		sp.LogFields(log.Error(err))
-		return manipulate.NewErrCannotBuildQuery(err.Error())
+		return manipulate.ErrCannotBuildQuery{Err: err}
 	}
 
 	data, err := elemental.Encode(s.encoding, object)
 	if err != nil {
 		sp.SetTag("error", true)
 		sp.LogFields(log.Error(err))
-		return manipulate.NewErrCannotMarshal(err.Error())
+		return manipulate.ErrCannotMarshal{Err: err}
 	}
 
 	response, err := s.send(mctx, http.MethodPost, url, bytes.NewReader(data), object, sp)
@@ -306,7 +306,7 @@ func (s *httpManipulator) Create(mctx manipulate.Context, object elemental.Ident
 func (s *httpManipulator) Update(mctx manipulate.Context, object elemental.Identifiable) error {
 
 	if object == nil {
-		return manipulate.NewErrCannotBuildQuery("nil object")
+		return manipulate.ErrCannotBuildQuery{Err: fmt.Errorf("nil object")}
 	}
 
 	if mctx == nil {
@@ -333,14 +333,14 @@ func (s *httpManipulator) Update(mctx manipulate.Context, object elemental.Ident
 	if err != nil {
 		sp.SetTag("error", true)
 		sp.LogFields(log.Error(err))
-		return manipulate.NewErrCannotBuildQuery(err.Error())
+		return manipulate.ErrCannotBuildQuery{Err: err}
 	}
 
 	data, err := elemental.Encode(s.encoding, object)
 	if err != nil {
 		sp.SetTag("error", true)
 		sp.LogFields(log.Error(err))
-		return manipulate.NewErrCannotMarshal(err.Error())
+		return manipulate.ErrCannotMarshal{Err: err}
 	}
 
 	response, err := s.send(mctx, method, url, bytes.NewReader(data), object, sp)
@@ -369,7 +369,7 @@ func (s *httpManipulator) Update(mctx manipulate.Context, object elemental.Ident
 func (s *httpManipulator) Delete(mctx manipulate.Context, object elemental.Identifiable) error {
 
 	if object == nil {
-		return manipulate.NewErrCannotBuildQuery("nil object")
+		return manipulate.ErrCannotBuildQuery{Err: fmt.Errorf("nil object")}
 	}
 
 	if mctx == nil {
@@ -386,7 +386,7 @@ func (s *httpManipulator) Delete(mctx manipulate.Context, object elemental.Ident
 	if err != nil {
 		sp.SetTag("error", true)
 		sp.LogFields(log.Error(err))
-		return manipulate.NewErrCannotBuildQuery(err.Error())
+		return manipulate.ErrCannotBuildQuery{Err: err}
 	}
 
 	response, err := s.send(mctx, http.MethodDelete, url, nil, object, sp)
@@ -409,7 +409,7 @@ func (s *httpManipulator) Delete(mctx manipulate.Context, object elemental.Ident
 }
 
 func (s *httpManipulator) DeleteMany(mctx manipulate.Context, identity elemental.Identity) error {
-	return manipulate.NewErrNotImplemented("DeleteMany not implemented in maniphttp")
+	return manipulate.ErrNotImplemented{Err: fmt.Errorf("DeleteMany not implemented in maniphttp")}
 }
 
 func (s *httpManipulator) Count(mctx manipulate.Context, identity elemental.Identity) (int, error) {
@@ -427,7 +427,7 @@ func (s *httpManipulator) Count(mctx manipulate.Context, identity elemental.Iden
 	if err != nil {
 		sp.SetTag("error", true)
 		sp.LogFields(log.Error(err))
-		return 0, manipulate.NewErrCannotBuildQuery(err.Error())
+		return 0, manipulate.ErrCannotBuildQuery{Err: err}
 	}
 
 	if _, err = s.send(mctx, http.MethodHead, url, nil, nil, sp); err != nil {
@@ -643,14 +643,14 @@ func (s *httpManipulator) send(
 		var currentRequestBody io.Reader
 		if body != nil {
 			if _, err := body.Seek(0, 0); err != nil {
-				return nil, manipulate.NewErrCannotBuildQuery(err.Error())
+				return nil, manipulate.ErrCannotBuildQuery{Err: err}
 			}
 			currentRequestBody = body
 		}
 
 		req, err := http.NewRequest(method, requrl, currentRequestBody)
 		if err != nil {
-			return nil, manipulate.NewErrCannotBuildQuery(err.Error())
+			return nil, manipulate.ErrCannotBuildQuery{Err: err}
 		}
 
 		if err = addQueryParameters(req, mctx); err != nil {
@@ -691,17 +691,17 @@ func (s *httpManipulator) send(
 			switch uerr.Err {
 
 			case context.Canceled:
-				return nil, manipulate.NewErrDisconnected("Client left")
+				return nil, manipulate.ErrDisconnected{Err: context.Canceled}
 
 			case context.DeadlineExceeded:
 				if lastError == nil {
-					lastError = manipulate.NewErrCannotCommunicate(snip.Snip(err, s.currentPassword()).Error())
+					lastError = manipulate.ErrCannotCommunicate{Err: fmt.Errorf(snip.Snip(err, s.currentPassword()).Error())}
 				}
 				goto RETRY
 
 			case io.ErrUnexpectedEOF, io.EOF:
 				if lastError == nil {
-					lastError = manipulate.NewErrCannotCommunicate(snip.Snip(err, s.currentPassword()).Error())
+					lastError = manipulate.ErrCannotCommunicate{Err: fmt.Errorf(snip.Snip(err, s.currentPassword()).Error())}
 				}
 				goto RETRY
 			}
@@ -712,7 +712,7 @@ func (s *httpManipulator) send(
 			case net.Error:
 
 				if lastError == nil {
-					lastError = manipulate.NewErrCannotCommunicate(snip.Snip(err, s.currentPassword()).Error())
+					lastError = manipulate.ErrCannotCommunicate{Err: fmt.Errorf(snip.Snip(err, s.currentPassword()).Error())}
 				}
 
 				// check if the connection has been reset by the gateway
@@ -728,10 +728,10 @@ func (s *httpManipulator) send(
 				goto RETRY
 
 			case x509.UnknownAuthorityError, x509.CertificateInvalidError, x509.HostnameError:
-				return nil, manipulate.NewErrTLS(err.Error())
+				return nil, manipulate.ErrTLS{Err: err}
 
 			default:
-				return nil, manipulate.NewErrCannotExecuteQuery(err.Error())
+				return nil, manipulate.ErrCannotExecuteQuery{Err: err}
 			}
 		}
 
@@ -743,27 +743,27 @@ func (s *httpManipulator) send(
 		switch response.StatusCode {
 
 		case http.StatusBadGateway:
-			lastError = manipulate.NewErrCannotCommunicate("Bad gateway")
+			lastError = manipulate.ErrCannotCommunicate{Err: fmt.Errorf("Bad gateway")}
 			goto RETRY
 
 		case http.StatusServiceUnavailable:
-			lastError = manipulate.NewErrCannotCommunicate("Service unavailable")
+			lastError = manipulate.ErrCannotCommunicate{Err: fmt.Errorf("Service unavailable")}
 			goto RETRY
 
 		case http.StatusGatewayTimeout:
-			lastError = manipulate.NewErrCannotCommunicate("Gateway timeout")
+			lastError = manipulate.ErrCannotCommunicate{Err: fmt.Errorf("Gateway timeout")}
 			goto RETRY
 
 		case http.StatusLocked:
-			lastError = manipulate.NewErrLocked("The api has been locked down by the server.")
+			lastError = manipulate.ErrLocked{Err: fmt.Errorf("The api has been locked down by the server.")}
 			goto RETRY
 
 		case http.StatusRequestTimeout:
-			lastError = manipulate.NewErrCannotCommunicate("Request Timeout")
+			lastError = manipulate.ErrCannotCommunicate{Err: fmt.Errorf("Request Timeout")}
 			goto RETRY
 
 		case http.StatusTooManyRequests:
-			lastError = manipulate.NewErrTooManyRequests("Too Many Requests")
+			lastError = manipulate.ErrTooManyRequests{Err: fmt.Errorf("Too Many Requests")}
 			retryCurve = s.strongBackoffCurve
 			goto RETRY
 		}

--- a/maniphttp/manipulator.go
+++ b/maniphttp/manipulator.go
@@ -755,7 +755,7 @@ func (s *httpManipulator) send(
 			goto RETRY
 
 		case http.StatusLocked:
-			lastError = manipulate.ErrLocked{Err: fmt.Errorf("The api has been locked down by the server.")}
+			lastError = manipulate.ErrLocked{Err: fmt.Errorf("The api has been locked down by the server")}
 			goto RETRY
 
 		case http.StatusRequestTimeout:

--- a/maniphttp/manipulator_test.go
+++ b/maniphttp/manipulator_test.go
@@ -1675,7 +1675,7 @@ func TestHTTP_send(t *testing.T) {
 
 		So(err, ShouldNotBeNil)
 		So(err, ShouldHaveSameTypeAs, manipulate.ErrLocked{})
-		So(err.Error(), ShouldEqual, "Cannot communicate: The api has been locked down by the server.")
+		So(err.Error(), ShouldEqual, "Cannot communicate: The api has been locked down by the server")
 
 		So(resp, ShouldBeNil)
 

--- a/maniphttp/manipulator_test.go
+++ b/maniphttp/manipulator_test.go
@@ -1816,7 +1816,7 @@ func TestHTTP_send(t *testing.T) {
 
 		So(err, ShouldNotBeNil)
 		So(err, ShouldHaveSameTypeAs, manipulate.ErrDisconnected{})
-		So(err.Error(), ShouldEqual, `Disconnected: Client left`)
+		So(err.Error(), ShouldEqual, `Disconnected: context canceled`)
 
 		So(resp, ShouldBeNil)
 	})

--- a/maniphttp/options.go
+++ b/maniphttp/options.go
@@ -143,12 +143,12 @@ func OptionSendCredentialsAsCookie(key string) Option {
 //
 // For instance, take the following map:
 //      map[float64]error{
-//          0.10: manipulate.NewErrCannotBuildQuery("oh no"),
-//          0.25: manipulate.NewErrCannotCommunicate("service is gone"),
+//          0.10: manipulate.ErrCannotBuildQuery{Err: fmt.Errorf("Oh no!")},
+//          0.25: manipulate.ErrCannotCommunicate{Err: fmt.Errorf("Service is gone")},
 //      }
 //
-// It will return manipulate.NewErrCannotBuildQuery around 10% of the requests,
-// manipulate.NewErrCannotCommunicate around 25% of the requests.
+// It will return manipulate.ErrCannotBuildQuery around 10% of the requests,
+// manipulate.ErrCannotCommunicate around 25% of the requests.
 // This is obviously designed for simulating backend failures and should
 // not be used in production, obviously.
 func OptionSimulateFailures(failureSimulations map[float64]error) Option {

--- a/maniphttp/utils.go
+++ b/maniphttp/utils.go
@@ -86,12 +86,12 @@ func addQueryParameters(req *http.Request, ctx manipulate.Context) error {
 func decodeData(r *http.Response, dest interface{}) (err error) {
 
 	if r.Body == nil {
-		return manipulate.NewErrCannotUnmarshal("nil reader")
+		return manipulate.ErrCannotUnmarshal{Err: fmt.Errorf("nil reader")}
 	}
 
 	var data []byte
 	if data, err = ioutil.ReadAll(r.Body); err != nil {
-		return manipulate.NewErrCannotUnmarshal(fmt.Sprintf("unable to read data: %s", err.Error()))
+		return manipulate.ErrCannotUnmarshal{Err: fmt.Errorf("unable to read data: %w", err)}
 	}
 
 	encoding := elemental.EncodingTypeJSON
@@ -103,7 +103,7 @@ func decodeData(r *http.Response, dest interface{}) (err error) {
 	}
 
 	if err = elemental.Decode(encoding, data, dest); err != nil {
-		return manipulate.NewErrCannotUnmarshal(fmt.Sprintf("%s. original data:\n%s", err.Error(), string(data)))
+		return manipulate.ErrCannotUnmarshal{Err: fmt.Errorf("%w. original data:\n%s", err, string(data))}
 	}
 
 	return nil

--- a/manipmongo/helpers.go
+++ b/manipmongo/helpers.go
@@ -225,7 +225,7 @@ func RunQuery(mctx manipulate.Context, operationFunc func() (interface{}, error)
 
 		select {
 		case <-mctx.Context().Done():
-			return nil, manipulate.NewErrCannotExecuteQuery(mctx.Context().Err().Error())
+			return nil, manipulate.ErrCannotExecuteQuery{Err: mctx.Context().Err()}
 		default:
 		}
 

--- a/manipmongo/utils.go
+++ b/manipmongo/utils.go
@@ -114,19 +114,19 @@ func prepareNextFilter(collection *mgo.Collection, orderingField string, next st
 func HandleQueryError(err error) error {
 
 	if _, ok := err.(net.Error); ok {
-		return manipulate.NewErrCannotCommunicate(err.Error())
+		return manipulate.ErrCannotCommunicate{Err: err}
 	}
 
 	if err == mgo.ErrNotFound {
-		return manipulate.NewErrObjectNotFound("cannot find the object for the given ID")
+		return manipulate.ErrObjectNotFound{Err: fmt.Errorf("cannot find the object for the given ID")}
 	}
 
 	if mgo.IsDup(err) {
-		return manipulate.NewErrConstraintViolation("duplicate key.")
+		return manipulate.ErrConstraintViolation{Err: fmt.Errorf("duplicate key.")}
 	}
 
 	if isConnectionError(err) {
-		return manipulate.NewErrCannotCommunicate(err.Error())
+		return manipulate.ErrCannotCommunicate{Err: err}
 	}
 
 	// see https://github.com/mongodb/mongo/blob/master/src/mongo/base/error_codes.err
@@ -147,9 +147,9 @@ func HandleQueryError(err error) error {
 		// NotMasterNoSlaveOk
 		// InterruptedAtShutdown
 		// InterruptedDueToStepDown
-		return manipulate.NewErrCannotCommunicate(err.Error())
+		return manipulate.ErrCannotCommunicate{Err: err}
 	default:
-		return manipulate.NewErrCannotExecuteQuery(err.Error())
+		return manipulate.ErrCannotExecuteQuery{Err: err}
 	}
 }
 

--- a/manipmongo/utils.go
+++ b/manipmongo/utils.go
@@ -122,7 +122,7 @@ func HandleQueryError(err error) error {
 	}
 
 	if mgo.IsDup(err) {
-		return manipulate.ErrConstraintViolation{Err: fmt.Errorf("duplicate key.")}
+		return manipulate.ErrConstraintViolation{Err: fmt.Errorf("duplicate key")}
 	}
 
 	if isConnectionError(err) {

--- a/manipmongo/utils_test.go
+++ b/manipmongo/utils_test.go
@@ -57,7 +57,7 @@ func Test_HandleQueryError(t *testing.T) {
 			args{
 				&mgo.LastError{Code: 11000},
 			},
-			"Constraint violation: duplicate key.",
+			"Constraint violation: duplicate key",
 		},
 		{
 			"isConnectionError says yes",

--- a/manipvortex/manipulator_test.go
+++ b/manipvortex/manipulator_test.go
@@ -258,7 +258,7 @@ func Test_run(t *testing.T) {
 		So(err, ShouldBeNil)
 
 		m.MockRetrieveMany(t, func(mctx manipulate.Context, dest elemental.Identifiables) error {
-			return manipulate.NewErrObjectNotFound("testing")
+			return manipulate.ErrObjectNotFound{Err: fmt.Errorf("testing")}
 		})
 
 		_, err = New(
@@ -430,7 +430,7 @@ func Test_Retrieve(t *testing.T) {
 
 			mctx := manipulate.NewContext(ctx, manipulate.ContextOptionReadConsistency(manipulate.ReadConsistencyStrong))
 			m.MockRetrieve(t, func(ctx manipulate.Context, object elemental.Identifiable) error {
-				return manipulate.NewErrCannotCommunicate("test")
+				return manipulate.ErrCannotCommunicate{Err: fmt.Errorf("test")}
 			})
 			err := v.Retrieve(mctx, o)
 			So(err, ShouldNotBeNil)
@@ -554,7 +554,7 @@ func Test_Create(t *testing.T) {
 
 			Convey("When the backend fails, the object must be not be stored in the DB", func() {
 				m.MockCreate(t, func(mctx manipulate.Context, object elemental.Identifiable) error {
-					return manipulate.NewErrConstraintViolation("test")
+					return manipulate.ErrConstraintViolation{Err: fmt.Errorf("test")}
 				})
 
 				obj := newObject("obj1", []string{"label"})
@@ -573,7 +573,7 @@ func Test_Create(t *testing.T) {
 			Convey("When the has a hook function that prevents execution, it should not commit to the DB", func() {
 
 				m.MockCreate(t, func(mctx manipulate.Context, object elemental.Identifiable) error {
-					return manipulate.NewErrConstraintViolation("test")
+					return manipulate.ErrConstraintViolation{Err: fmt.Errorf("test")}
 				})
 
 				obj := newObject("obj1", []string{"label"})
@@ -685,7 +685,7 @@ func Test_Update(t *testing.T) {
 
 			Convey("When the backend fails, the object must not be updated", func() {
 				m.MockUpdate(t, func(mctx manipulate.Context, object elemental.Identifiable) error {
-					return manipulate.NewErrCannotBuildQuery("test")
+					return manipulate.ErrCannotBuildQuery{Err: fmt.Errorf("test")}
 				})
 
 				updatedObject := newObject("", []string{"a=b"})
@@ -704,7 +704,7 @@ func Test_Update(t *testing.T) {
 
 			Convey("When the vortex has a hook function that prevents updates, the object must not be updated", func() {
 				m.MockUpdate(t, func(mctx manipulate.Context, object elemental.Identifiable) error {
-					return manipulate.NewErrCannotBuildQuery("test")
+					return manipulate.ErrCannotBuildQuery{Err: fmt.Errorf("test")}
 				})
 
 				updatedObject := newObject("", []string{"a=b"})
@@ -815,7 +815,7 @@ func Test_Delete(t *testing.T) {
 
 			Convey("When the backend fail, the object must not be deleted", func() {
 				m.MockDelete(t, func(mctx manipulate.Context, object elemental.Identifiable) error {
-					return manipulate.NewErrCannotBuildQuery("test")
+					return manipulate.ErrCannotBuildQuery{Err: fmt.Errorf("test")}
 				})
 
 				updatedObject := newObject("", []string{"a=b"})
@@ -832,7 +832,7 @@ func Test_Delete(t *testing.T) {
 
 			Convey("When the vortex has a hook function that prevents deletes, the object must not be deleted", func() {
 				m.MockDelete(t, func(mctx manipulate.Context, object elemental.Identifiable) error {
-					return manipulate.NewErrCannotBuildQuery("test")
+					return manipulate.ErrCannotBuildQuery{Err: fmt.Errorf("test")}
 				})
 
 				updatedObject := newObject("", []string{"a=b"})
@@ -1080,7 +1080,7 @@ func Test_WriteThroughBackend(t *testing.T) {
 					}
 
 					m.MockDelete(t, func(ctx manipulate.Context, object elemental.Identifiable) error {
-						return manipulate.NewErrCannotCommit("failed")
+						return manipulate.ErrCannotCommit{Err: fmt.Errorf("failed")}
 					})
 					err = v.Delete(nil, newObject)
 					So(err, ShouldNotBeNil)
@@ -1357,7 +1357,7 @@ func Test_WriteBackBackend(t *testing.T) {
 				obj3.ID = "ID3"
 
 				m.MockCreate(t, func(ctx manipulate.Context, object elemental.Identifiable) error {
-					return manipulate.NewErrCannotCommunicate("testing")
+					return manipulate.ErrCannotCommunicate{Err: fmt.Errorf("testing")}
 				})
 
 				err := v.Create(nil, obj3)
@@ -1426,7 +1426,7 @@ func Test_WriteBackBackend(t *testing.T) {
 				})
 
 				m.MockUpdate(t, func(ctx manipulate.Context, object elemental.Identifiable) error {
-					return manipulate.NewErrCannotCommunicate("test")
+					return manipulate.ErrCannotCommunicate{Err: fmt.Errorf("test")}
 				})
 
 				err := v.Create(nil, obj3)


### PR DESCRIPTION
This patch improve the old manipulate.Error to support error wrapping. Old methods have been deprecated