### PR TITLE
CNS-2022 - Upsert operation always result in Create if the object id …

### DIFF
--- a/manipmongo/helpers.go
+++ b/manipmongo/helpers.go
@@ -277,3 +277,10 @@ func GetAttributeEncrypter(manipulator manipulate.Manipulator) elemental.Attribu
 
 	return m.attributeEncrypter
 }
+
+// IsUpsert returns True if the mongo request is an Upsert operation, false otherwise.
+func IsUpsert(mctx manipulate.Context) bool {
+	_, upsert := mctx.(opaquer).Opaque()[opaqueKeyUpsert]
+	return upsert
+}
+


### PR DESCRIPTION
…is used as the default value for calculating sharding hashes

The fix was to not include zhash to the filter for upsert if
the object's zhash strategy uses a custom hash key instead of the
the default strategy of hashing mongo object id.