### PR TITLE
fixed: Adding a helper function to check if a manipmongo context is u…

### DIFF
--- a/manipmongo/helpers.go
+++ b/manipmongo/helpers.go
@@ -277,3 +277,9 @@ func GetAttributeEncrypter(manipulator manipulate.Manipulator) elemental.Attribu
 
 	return m.attributeEncrypter
 }
+
+// IsUpsert returns True if the mongo request is an Upsert operation, false otherwise.
+func IsUpsert(mctx manipulate.Context) bool {
+	_, upsert := mctx.(opaquer).Opaque()[opaqueKeyUpsert]
+	return upsert
+}

--- a/manipmongo/helpers_test.go
+++ b/manipmongo/helpers_test.go
@@ -535,3 +535,25 @@ func TestGetAttributeEncrypter(t *testing.T) {
 		})
 	})
 }
+
+func TestIsUpsert(t *testing.T) {
+
+	Convey("Given I a manipulate context with upsert set", t, func() {
+		mctx := manipulate.NewContext(context.Background(), ContextOptionUpsert(nil))
+		Convey("When I call IsUpsert", func() {
+			Convey("Then it should return true", func() {
+				So(IsUpsert(mctx), ShouldEqual, true)
+			})
+		})
+	})
+
+
+	Convey("Given I a plain vanilla manipulate context with upsert NOT set", t, func() {
+		mctx := manipulate.NewContext(context.Background())
+		Convey("When I call IsUpsert", func() {
+			Convey("Then it should return false", func() {
+				So(IsUpsert(mctx), ShouldEqual, false)
+			})
+		})
+	})
+}


### PR DESCRIPTION
…psert.

Related to - Mongo Upsert was creating a new object in the DB even if the key exists in DB.
Ref: CNS-2022